### PR TITLE
remove close overridable def because it is superfluous

### DIFF
--- a/lib/jetstream/pull_consumer.ex
+++ b/lib/jetstream/pull_consumer.ex
@@ -97,13 +97,7 @@ defmodule Jetstream.PullConsumer do
         Jetstream.PullConsumer.child_spec(__MODULE__, init_arg)
       end
 
-      @spec close(pull_consumer :: GenServer.server()) :: :ok
-      def close(pull_consumer) do
-        Jetstream.PullConsumer.close(pull_consumer)
-      end
-
-      defoverridable child_spec: 1,
-                     close: 1
+      defoverridable child_spec: 1
     end
   end
 

--- a/test/pull_consumer_test.exs
+++ b/test/pull_consumer_test.exs
@@ -108,7 +108,7 @@ defmodule Jetstream.PullConsumerTest do
 
       ref = Process.monitor(pid)
 
-      assert :ok = ExamplePullConsumer.close(pid)
+      assert :ok = Jetstream.PullConsumer.close(pid)
 
       assert_receive {:DOWN, ^ref, :process, ^pid, :shutdown}
     end


### PR DESCRIPTION
Users can simply call `PullConsumer.close/1` directly.