### PR TITLE
break out Worker module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ jetstream-*.tar
 
 # ASDF tool versions
 .tool-versions
+
+# Ignore the tmp directory used to stash things during development
+/tmp

--- a/lib/jetstream/pull_consumer/connection_options.ex
+++ b/lib/jetstream/pull_consumer/connection_options.ex
@@ -2,7 +2,7 @@ defmodule Jetstream.PullConsumer.ConnectionOptions do
   @moduledoc false
 
   @default_retry_timeout 1000
-  @default_retries 10
+  @default_retries :infinite
   @default_inbox_prefix "_INBOX."
 
   @enforce_keys [

--- a/lib/jetstream/pull_consumer/worker.ex
+++ b/lib/jetstream/pull_consumer/worker.ex
@@ -1,0 +1,66 @@
+defmodule Jetstream.PullConsumer.Worker do
+  @moduledoc false
+
+  use GenServer
+
+  alias Jetstream.PullConsumer.ConnectionOptions
+
+  require Logger
+
+  def start_link(init_arg, module, connection_options) do
+    GenServer.start_link(__MODULE__, {init_arg, module, connection_options})
+  end
+
+  def init({init_arg, module, connection_options = %ConnectionOptions{}}) do
+    o = connection_options
+    listening_topic = o.inbox_prefix <> nuid()
+    {:ok, sid} = Gnat.sub(o.connection_name, self(), listening_topic)
+
+    state = %{
+      conn: o.connection_name,
+      next_message_topic: "$JS.API.CONSUMER.MSG.NEXT.#{o.stream_name}.#{o.consumer_name}",
+      stream_name: o.stream_name,
+      consumer_name: o.consumer_name,
+      listening_topic: listening_topic,
+      module: module,
+      sid: sid,
+      callback_state: init_arg
+    }
+
+    next_message(state)
+
+    {:ok, state}
+  end
+
+  def handle_info({:msg, message}, state) do
+    case state.module.handle_message(message, state.callback_state) do
+      {:ack, callback_state} ->
+        Jetstream.ack_next(message, state.listening_topic)
+        {:noreply, %{state | callback_state: callback_state}}
+
+      {:nack, callback_state} ->
+        Jetstream.nack(message)
+        next_message(state)
+        {:noreply, %{state | callback_state: callback_state}}
+
+      {:noreply, callback_state} ->
+        next_message(state)
+        {:noreply, %{state | callback_state: callback_state}}
+    end
+  end
+
+  defp next_message(state) do
+    Logger.debug("Worker next_message #{inspect(state)}")
+
+    Gnat.pub(
+      state.conn,
+      state.next_message_topic,
+      "1",
+      reply_to: state.listening_topic
+    )
+  end
+
+  defp nuid() do
+    :crypto.strong_rand_bytes(12) |> Base.encode64()
+  end
+end


### PR DESCRIPTION
This addresses #36 by checking for the existence of the consumer during the connection phase. Only if we can find a connection, and we can successfully find the consumer definition in Jetstream, then we will link to the connection and start requesting messages.

The `Jetstream.PullConsumer.Server` module was handling a lot of logic, and as I was thinking about things like #41, I thought it would be a good idea to separate the code that handles jetstream logic, from the code that monitors our NATS/Jetstream connection.

This code also allows for setting `connection_retries: :infinite` which will continue attempting to connect forever. This better matches the use-cases that I've seen in the past where even if NATS were down for a long time, you would still want the rest of your application to continue working and wait for it to become available. Does that default sounds reasonable to other contributors? Or is it important in your use cases to crash if the NATS cluster is unreachable?

fix #36 