### PR TITLE
Validate names

### DIFF
--- a/lib/jetstream/api/stream.ex
+++ b/lib/jetstream/api/stream.ex
@@ -353,6 +353,9 @@ defmodule Jetstream.API.Stream do
       is_binary(Map.get(stream_settings, :name)) == false ->
         {:error, "name must be a string"}
 
+      String.contains?(stream_settings.name, [".", "*", ">", " ", "\t"]) ->
+        {:error, "invalid stream name, cannot contain '.', '>', '*', spaces or tabs"}
+
       Map.has_key?(stream_settings, :subjects) == false ->
         {:error, "You must specify a :subjects key"}
 

--- a/lib/jetstream/api/stream.ex
+++ b/lib/jetstream/api/stream.ex
@@ -353,8 +353,8 @@ defmodule Jetstream.API.Stream do
       is_binary(Map.get(stream_settings, :name)) == false ->
         {:error, "name must be a string"}
 
-      String.contains?(stream_settings.name, [".", "*", ">", " ", "\t"]) ->
-        {:error, "invalid stream name, cannot contain '.', '>', '*', spaces or tabs"}
+      valid_name?(stream_settings.name) == false ->
+        {:error, "invalid name: " <> invalid_name_message()}
 
       Map.has_key?(stream_settings, :subjects) == false ->
         {:error, "You must specify a :subjects key"}

--- a/lib/jetstream/api/util.ex
+++ b/lib/jetstream/api/util.ex
@@ -33,4 +33,12 @@ defmodule Jetstream.API.Util do
       _ -> target_map
     end
   end
+
+  def valid_name?(name) do
+    !String.contains?(name, [".", "*", ">", " ", "\t"])
+  end
+
+  def invalid_name_message do
+    "cannot contain '.', '>', '*', spaces or tabs"
+  end
 end

--- a/test/jetstream/api/consumer_test.exs
+++ b/test/jetstream/api/consumer_test.exs
@@ -151,4 +151,31 @@ defmodule Jetstream.API.ConsumerTest do
     assert :ok = Consumer.delete(:gnat, "STREAM4", "STREAM4")
     assert :ok = Stream.delete(:gnat, "STREAM4")
   end
+
+  test "validating stream and consumer names" do
+    assert {:error, reason} =
+             Consumer.create(:gnat, %Consumer{stream_name: "test.periods", durable_name: "foo"})
+
+    assert reason == "invalid stream_name: cannot contain '.', '>', '*', spaces or tabs"
+
+    assert {:error, reason} =
+             Consumer.create(:gnat, %Consumer{stream_name: nil, durable_name: "foo"})
+
+    assert reason == "must have a :stream_name set"
+
+    assert {:error, reason} =
+             Consumer.create(:gnat, %Consumer{stream_name: :foo, durable_name: "foo"})
+
+    assert reason == "stream_name must be a string"
+
+    assert {:error, reason} =
+             Consumer.create(:gnat, %Consumer{stream_name: "TEST_STREAM", durable_name: "foo.bar"})
+
+    assert reason == "invalid durable_name: cannot contain '.', '>', '*', spaces or tabs"
+
+    assert {:error, reason} =
+             Consumer.create(:gnat, %Consumer{stream_name: "TEST_STREAM", durable_name: :ohai})
+
+    assert reason == "durable_name must be a string"
+  end
 end

--- a/test/jetstream/api/stream_test.exs
+++ b/test/jetstream/api/stream_test.exs
@@ -78,4 +78,27 @@ defmodule Jetstream.API.StreamTest do
     assert result.retention == :workqueue
     assert result.storage == :memory
   end
+
+  test "validating stream names" do
+    assert {:error, reason} =
+             Stream.create(:gnat, %Stream{name: "test.periods", subjects: ["foo"]})
+
+    assert reason == "invalid stream name, cannot contain '.', '>', '*', spaces or tabs"
+
+    assert {:error, reason} =
+             Stream.create(:gnat, %Stream{name: "test>greater", subjects: ["foo"]})
+
+    assert reason == "invalid stream name, cannot contain '.', '>', '*', spaces or tabs"
+
+    assert {:error, reason} = Stream.create(:gnat, %Stream{name: "test_star*", subjects: ["foo"]})
+    assert reason == "invalid stream name, cannot contain '.', '>', '*', spaces or tabs"
+
+    assert {:error, reason} =
+             Stream.create(:gnat, %Stream{name: "test-space ", subjects: ["foo"]})
+
+    assert reason == "invalid stream name, cannot contain '.', '>', '*', spaces or tabs"
+
+    assert {:error, reason} = Stream.create(:gnat, %Stream{name: "\ttest-tab", subjects: ["foo"]})
+    assert reason == "invalid stream name, cannot contain '.', '>', '*', spaces or tabs"
+  end
 end

--- a/test/jetstream/api/stream_test.exs
+++ b/test/jetstream/api/stream_test.exs
@@ -83,22 +83,22 @@ defmodule Jetstream.API.StreamTest do
     assert {:error, reason} =
              Stream.create(:gnat, %Stream{name: "test.periods", subjects: ["foo"]})
 
-    assert reason == "invalid stream name, cannot contain '.', '>', '*', spaces or tabs"
+    assert reason == "invalid name: cannot contain '.', '>', '*', spaces or tabs"
 
     assert {:error, reason} =
              Stream.create(:gnat, %Stream{name: "test>greater", subjects: ["foo"]})
 
-    assert reason == "invalid stream name, cannot contain '.', '>', '*', spaces or tabs"
+    assert reason == "invalid name: cannot contain '.', '>', '*', spaces or tabs"
 
     assert {:error, reason} = Stream.create(:gnat, %Stream{name: "test_star*", subjects: ["foo"]})
-    assert reason == "invalid stream name, cannot contain '.', '>', '*', spaces or tabs"
+    assert reason == "invalid name: cannot contain '.', '>', '*', spaces or tabs"
 
     assert {:error, reason} =
              Stream.create(:gnat, %Stream{name: "test-space ", subjects: ["foo"]})
 
-    assert reason == "invalid stream name, cannot contain '.', '>', '*', spaces or tabs"
+    assert reason == "invalid name: cannot contain '.', '>', '*', spaces or tabs"
 
     assert {:error, reason} = Stream.create(:gnat, %Stream{name: "\ttest-tab", subjects: ["foo"]})
-    assert reason == "invalid stream name, cannot contain '.', '>', '*', spaces or tabs"
+    assert reason == "invalid name: cannot contain '.', '>', '*', spaces or tabs"
   end
 end


### PR DESCRIPTION
Addresses #38 

This adds some client-side validation to avoid the long timeout errors that we get back if we try to create a stream or consumer with an invalid name.