### PR TITLE
Fix ConnectivityTest wonky

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,8 @@
 ExUnit.start()
 
+# set assert_receive default timeout
+Application.put_env(:ex_unit, :assert_receive_timeout, 1_000)
+
 # cleanup any streams left over by previous test runs
 {:ok, conn} = Gnat.start_link()
 {:ok, %{streams: streams}} = Jetstream.API.Stream.list(conn)


### PR DESCRIPTION
Looks like the default 100 ms is too low. After setting it to 1000 ms I haven't encountered the problem.

fix #37 