### PR TITLE
Fix Stream non-standard settings test not compatibile with NATS 2.8

### DIFF
--- a/test/jetstream/api/stream_test.exs
+++ b/test/jetstream/api/stream_test.exs
@@ -68,13 +68,13 @@ defmodule Jetstream.API.StreamTest do
       name: "ARGS_TEST",
       subjects: ["ARGS_TEST.*"],
       retention: :workqueue,
-      duplicate_window: 1_000_000,
+      duplicate_window: 100_000_000,
       storage: :memory
     }
 
     assert {:ok, %{config: result}} = Stream.create(:gnat, stream)
     assert result.name == "ARGS_TEST"
-    assert result.duplicate_window == 1_000_000
+    assert result.duplicate_window == 100_000_000
     assert result.retention == :workqueue
     assert result.storage == :memory
   end


### PR DESCRIPTION
NATS now requires the duplicate window to be >= 100 milliseconds (>= 1 000 000 nanoseconds)

Fix #49 