### PR TITLE
Fix KV.contents bug with occasional invalid consumer name

### DIFF
--- a/lib/jetstream/api/kv.ex
+++ b/lib/jetstream/api/kv.ex
@@ -157,13 +157,13 @@ defmodule Jetstream.API.KV do
 
   ## Examples
 
-      iex>{:ok, %{"key1" => "value1}} = Jetstream.API.KV.contents(:gnat, "my_bucket")
+      iex>{:ok, %{"key1" => "value1"}} = Jetstream.API.KV.contents(:gnat, "my_bucket")
   """
   @spec contents(conn :: Gnat.t(), bucket_name :: binary()) :: {:ok, map()} | {:error, binary()}
   def contents(conn, bucket_name) do
     stream = stream_name(bucket_name)
     inbox = Util.reply_inbox()
-    consumer_name = "all_key_values_consumer_#{Util.nuid()}"
+    consumer_name = "all_key_values_consumer_#{System.unique_integer([:positive, :monotonic])}"
 
     with {:ok, sub} <- Gnat.sub(conn, self(), inbox),
          {:ok, _consumer} <-

--- a/lib/jetstream/api/kv.ex
+++ b/lib/jetstream/api/kv.ex
@@ -163,7 +163,7 @@ defmodule Jetstream.API.KV do
   def contents(conn, bucket_name) do
     stream = stream_name(bucket_name)
     inbox = Util.reply_inbox()
-    consumer_name = "all_key_values_consumer_#{System.unique_integer([:positive, :monotonic])}"
+    consumer_name = "all_key_values_consumer_#{Util.nuid()}"
 
     with {:ok, sub} <- Gnat.sub(conn, self(), inbox),
          {:ok, _consumer} <-

--- a/lib/jetstream/api/util.ex
+++ b/lib/jetstream/api/util.ex
@@ -52,6 +52,6 @@ defmodule Jetstream.API.Util do
   def reply_inbox(prefix), do: prefix <> nuid()
 
   def nuid() do
-    :crypto.strong_rand_bytes(12) |> Base.encode64()
+    :crypto.strong_rand_bytes(12) |> Base.url_encode64()
   end
 end


### PR DESCRIPTION
Using the `nuid` function to create a unique consumer name sometimes created invalid consumer names that included a `/` character. Fixing this by using a random integer instead.