### PR TITLE
Add support for a watch function to subscribe to all changes in a bucket

### DIFF
--- a/lib/jetstream/api/kv.ex
+++ b/lib/jetstream/api/kv.ex
@@ -238,6 +238,8 @@ defmodule Jetstream.API.KV do
         end
 
       {:msg, %{topic: key, body: body}} ->
+        key = subject_to_key(key, bucket_name)
+
         handler.(:key_added, key, body)
     end
 

--- a/lib/jetstream/api/kv.ex
+++ b/lib/jetstream/api/kv.ex
@@ -190,7 +190,7 @@ defmodule Jetstream.API.KV do
 
   ## Examples
 
-      iex>{:ok, sub, consumer} = KV.watch(:gnat, "my_bucket", fn action, key, value -> IO.puts(action) end)
+      iex>{:ok, _watchres} = KV.watch(:gnat, "my_bucket", fn action, key, value -> IO.puts(action) end)
   """
   # @type watch_handler  (:key_added | :key_removed, String.t(), binary() -> nil)
   # @spec watch(conn :: Gnat.t(), bucket_name :: binary(), handler :: watch_handler()) :: {:ok, {pid(), String.t()}}

--- a/lib/jetstream/api/kv.ex
+++ b/lib/jetstream/api/kv.ex
@@ -192,8 +192,9 @@ defmodule Jetstream.API.KV do
 
       iex>{:ok, _watchres} = KV.watch(:gnat, "my_bucket", fn action, key, value -> IO.puts(action) end)
   """
-  # @type watch_handler  (:key_added | :key_removed, String.t(), binary() -> nil)
-  # @spec watch(conn :: Gnat.t(), bucket_name :: binary(), handler :: watch_handler()) :: {:ok, {pid(), String.t()}}
+  @type watch_handler :: (:key_added | :key_removed, String.t(), binary() -> nil)
+  @spec watch(conn :: Gnat.t(), bucket_name :: binary(), handler :: watch_handler()) ::
+          {:ok, {pid(), String.t()}} | {:error, any}
   def watch(conn, bucket_name, handler) do
     stream = stream_name(bucket_name)
     inbox = Util.reply_inbox()

--- a/lib/jetstream/api/kv.ex
+++ b/lib/jetstream/api/kv.ex
@@ -192,7 +192,7 @@ defmodule Jetstream.API.KV do
 
       iex>{:ok, _watchres} = KV.watch(:gnat, "my_bucket", fn action, key, value -> IO.puts(action) end)
   """
-  @type watch_handler :: (:key_added | :key_removed, String.t(), binary() -> nil)
+  @type watch_handler :: (:key_added | :key_deleted, String.t(), binary() -> nil)
   @spec watch(conn :: Gnat.t(), bucket_name :: binary(), handler :: watch_handler()) ::
           {:ok, {pid(), String.t()}} | {:error, any}
   def watch(conn, bucket_name, handler) do

--- a/lib/jetstream/api/kv/watcher.ex
+++ b/lib/jetstream/api/kv/watcher.ex
@@ -1,0 +1,89 @@
+defmodule Jetstream.API.KV.Watcher do
+  @moduledoc """
+  The watcher server establishes a subscription to the changes that occur to a given key-value bucket. The
+  consumer-supplied handler function will be sent an indicator as to whether the change is a delete or an add,
+  as well as the key being changed and the value (if it was added).
+
+  Ensure that you call `stop` with a watcher pid when you no longer need to be notified about key changes
+  """
+  use GenServer
+
+  alias Jetstream.API.{Consumer, KV, Util}
+
+  @operation_header "kv-operation"
+  @operation_del "DEL"
+
+  @type keywatch_handler ::
+          (action :: :key_deleted | :key_added, key :: String.t(), value :: any() -> nil)
+
+  @type watcher_options ::
+          {:conn, Gnat.t()}
+          | {:bucket_name, String.t()}
+          | {:handler, keywatch_handler()}
+
+  @spec start_link(opts :: [watcher_options()]) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  def stop(pid) do
+    GenServer.stop(pid)
+  end
+
+  def init(opts) do
+    {:ok, {sub, consumer_name}} = subscribe(opts[:conn], opts[:bucket_name])
+
+    {:ok,
+     %{
+       handler: opts[:handler],
+       conn: opts[:conn],
+       bucket_name: opts[:bucket_name],
+       sub: sub,
+       consumer_name: consumer_name
+     }}
+  end
+
+  def terminate(_reason, state) do
+    stream = KV.stream_name(state.bucket_name)
+    :ok = Gnat.unsub(state.conn, state.sub)
+    :ok = Consumer.delete(state.conn, stream, state.consumer_name)
+  end
+
+  # Received from NATS when headers are on the message (delete)
+  def handle_info({:msg, %{topic: key, body: body, headers: headers}}, state) do
+    key = KV.subject_to_key(key, state.bucket_name)
+
+    if {@operation_header, @operation_del} in headers do
+      state.handler.(:key_deleted, key, body)
+    end
+
+    {:noreply, state}
+  end
+
+  # Received from NATS with no headers (add)
+  def handle_info({:msg, %{topic: key, body: body}}, state) do
+    key = KV.subject_to_key(key, state.bucket_name)
+
+    state.handler.(:key_added, key, body)
+    {:noreply, state}
+  end
+
+  defp subscribe(conn, bucket_name) do
+    stream = KV.stream_name(bucket_name)
+    inbox = Util.reply_inbox()
+    consumer_name = "all_key_values_watcher_#{Util.nuid()}"
+
+    with {:ok, sub} <- Gnat.sub(conn, self(), inbox),
+         {:ok, _consumer} <-
+           Consumer.create(conn, %Consumer{
+             durable_name: consumer_name,
+             deliver_subject: inbox,
+             stream_name: stream,
+             ack_policy: :none,
+             max_ack_pending: -1,
+             max_deliver: 1
+           }) do
+      {:ok, {sub, consumer_name}}
+    end
+  end
+end

--- a/test/jetstream/api/kv_test.exs
+++ b/test/jetstream/api/kv_test.exs
@@ -76,21 +76,22 @@ defmodule Jetstream.API.KVTest do
     test "detects key added and removed keys", %{bucket: bucket} do
       test_pid = self()
 
-      {:ok, watchres} =
+      {:ok, watch_result} =
         KV.watch(:gnat, bucket, fn action, key, value ->
           send(test_pid, {action, key, value})
         end)
 
       KV.put_value(:gnat, bucket, "foo", "bar")
-      KV.put_value(:gnat, bucket, "baz", "quz")
-      KV.delete_key(:gnat, bucket, "baz")
-
       assert_receive({:key_added, "foo", "bar"})
+
+      KV.put_value(:gnat, bucket, "baz", "quz")
       assert_receive({:key_added, "baz", "quz"})
+
+      KV.delete_key(:gnat, bucket, "baz")
       # key deletions don't carry the data removed
       assert_receive({:key_deleted, "baz", ""})
 
-      KV.unwatch(:gnat, bucket, watchres)
+      KV.unwatch(:gnat, bucket, watch_result)
 
       :ok = KV.delete_bucket(:gnat, bucket)
     end

--- a/test/jetstream/api/kv_test.exs
+++ b/test/jetstream/api/kv_test.exs
@@ -76,7 +76,7 @@ defmodule Jetstream.API.KVTest do
     test "detects key added and removed keys", %{bucket: bucket} do
       test_pid = self()
 
-      {:ok, watch_result} =
+      {:ok, watcher_pid} =
         KV.watch(:gnat, bucket, fn action, key, value ->
           send(test_pid, {action, key, value})
         end)
@@ -91,7 +91,7 @@ defmodule Jetstream.API.KVTest do
       # key deletions don't carry the data removed
       assert_receive({:key_deleted, "baz", ""})
 
-      KV.unwatch(:gnat, bucket, watch_result)
+      KV.unwatch(watcher_pid)
 
       :ok = KV.delete_bucket(:gnat, bucket)
     end

--- a/test/jetstream/api/kv_test.exs
+++ b/test/jetstream/api/kv_test.exs
@@ -66,6 +66,34 @@ defmodule Jetstream.API.KVTest do
     assert :ok = KV.delete_bucket(:gnat, "KEY_PUT_TEST")
   end
 
+  describe "watch/3" do
+    setup do
+      bucket = "KEY_WATCH_TEST"
+      {:ok, _} = KV.create_bucket(:gnat, bucket)
+      %{bucket: bucket}
+    end
+
+    test "detects key added and removed keys", %{bucket: bucket} do
+      {:ok, watchres} =
+        KV.watch(:gnat, bucket, fn action, key, value ->
+          # turn this into an assert?
+          IO.inspect(action)
+          IO.inspect(key)
+          IO.inspect(value)
+        end)
+
+      KV.put_value(:gnat, bucket, "foo", "bar")
+      KV.put_value(:gnat, bucket, "baz", "quz")
+      KV.delete_key(:gnat, bucket, "baz")
+
+      # remove this
+      :timer.sleep(500)
+      KV.unwatch(:gnat, bucket, watchres)
+
+      :ok = KV.delete_bucket(:gnat, bucket)
+    end
+  end
+
   describe "contents/2" do
     setup do
       bucket = "KEY_LIST_TEST"


### PR DESCRIPTION
This is a not-yet-good-enough solution to #71 . I'm not happy with the ergonomics of the API or that I haven't figured out how to do a proper assert in the test, but hopefully this will give you a straw person to poke at and suggest how to make this acceptable.

I also couldn't get the syntax right on the type specs.