### PR TITLE
Make erlang versions specific

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,11 +16,11 @@ jobs:
     strategy:
       matrix:
         pair:
-          - otp: "23"
+          - otp: "23.3.4"
             elixir: "1.10"
             nats: "2.2.0"
 
-          - otp: "24"
+          - otp: "24.3.4"
             elixir: "main"
             nats: "latest"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         pair:
-          - otp: "23.3.4"
-            elixir: "1.10"
+          - otp: "24.3.4"
+            elixir: "1.12"
             nats: "2.2.0"
 
           - otp: "24.3.4"


### PR DESCRIPTION
Trying to fix errors here: https://github.com/mmmries/jetstream/actions/runs/3659625507/jobs/6185833544

```
Error: Requested Erlang/OTP version (23) not found in version list (should you be using option 'version-type': 'strict'?)
```