### PR TITLE
KV bucket functions are sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.7
+
+* Makes `KV.put_value`, `KV.create_key`, `KV.delete_key`, and `KV.purge_key` synchronous
+
 ## 0.0.6
 
 * Adds KV watcher https://github.com/mmmries/jetstream/pull/72

--- a/lib/jetstream/api/kv.ex
+++ b/lib/jetstream/api/kv.ex
@@ -90,9 +90,16 @@ defmodule Jetstream.API.KV do
       iex>:ok = Jetstream.API.KV.create_key(:gnat, "my_bucket", "my_key", "my_value")
   """
   @spec create_key(conn :: Gnat.t(), bucket_name :: binary(), key :: binary(), value :: binary()) ::
-          :ok
-  def create_key(conn, bucket_name, key, value) do
-    Gnat.pub(conn, key_name(bucket_name, key), value)
+          :ok | {:error, any()}
+  def create_key(conn, bucket_name, key, value, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, 5_000)
+
+    reply = Gnat.request(conn, key_name(bucket_name, key), value, receive_timeout: timeout)
+
+    case reply do
+      {:ok, _} -> :ok
+      error -> error
+    end
   end
 
   @doc """

--- a/lib/jetstream/api/kv.ex
+++ b/lib/jetstream/api/kv.ex
@@ -145,9 +145,16 @@ defmodule Jetstream.API.KV do
       iex>:ok = Jetstream.API.KV.put_value(:gnat, "my_bucket", "my_key", "my_value")
   """
   @spec put_value(conn :: Gnat.t(), bucket_name :: binary(), key :: binary(), value :: binary()) ::
-          :ok
-  def put_value(conn, bucket_name, key, value) do
-    Gnat.pub(conn, key_name(bucket_name, key), value)
+          :ok | {:error, any()}
+  def put_value(conn, bucket_name, key, value, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, 5_000)
+
+    reply = Gnat.request(conn, key_name(bucket_name, key), value, receive_timeout: timeout)
+
+    case reply do
+      {:ok, _} -> :ok
+      error -> error
+    end
   end
 
   @doc """

--- a/lib/jetstream/api/kv.ex
+++ b/lib/jetstream/api/kv.ex
@@ -102,9 +102,18 @@ defmodule Jetstream.API.KV do
 
       iex>:ok = Jetstream.API.KV.delete_key(:gnat, "my_bucket", "my_key")
   """
-  @spec delete_key(conn :: Gnat.t(), bucket_name :: binary(), key :: binary()) :: :ok
-  def delete_key(conn, bucket_name, key) do
-    Gnat.pub(conn, key_name(bucket_name, key), "", headers: [{"KV-Operation", "DEL"}])
+  @spec delete_key(conn :: Gnat.t(), bucket_name :: binary(), key :: binary()) :: :ok | {:error, any()}
+  def delete_key(conn, bucket_name, key, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, 5_000)
+
+    reply = Gnat.request(conn, key_name(bucket_name, key), "",
+      headers: [{"KV-Operation", "DEL"}], receive_timeout: timeout
+    )
+
+    case reply do
+      {:ok, _} -> :ok
+      error -> error
+    end
   end
 
   @doc """
@@ -114,11 +123,18 @@ defmodule Jetstream.API.KV do
 
       iex>:ok = Jetstream.API.KV.purge_key(:gnat, "my_bucket", "my_key")
   """
-  @spec purge_key(conn :: Gnat.t(), bucket_name :: binary(), key :: binary()) :: :ok
-  def purge_key(conn, bucket_name, key) do
-    Gnat.pub(conn, key_name(bucket_name, key), "",
-      headers: [{"KV-Operation", "PURGE"}, {"Nats-Rollup", "sub"}]
+  @spec purge_key(conn :: Gnat.t(), bucket_name :: binary(), key :: binary()) :: :ok | {:error, any()}
+  def purge_key(conn, bucket_name, key, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, 5_000)
+
+    reply = Gnat.request(conn, key_name(bucket_name, key), "",
+      headers: [{"KV-Operation", "PURGE"}, {"Nats-Rollup", "sub"}], receive_timeout: timeout
     )
+
+    case reply do
+      {:ok, _} -> :ok
+      error -> error
+    end
   end
 
   @doc """
@@ -142,7 +158,7 @@ defmodule Jetstream.API.KV do
       iex>"my_value" = Jetstream.API.KV.get_value(:gnat, "my_bucket", "my_key")
   """
   @spec get_value(conn :: Gnat.t(), bucket_name :: binary(), key :: binary()) ::
-          binary() | {:error, any()}
+          binary() | {:error, any()} | nil
   def get_value(conn, bucket_name, key) do
     case Stream.get_message(conn, stream_name(bucket_name), %{
            last_by_subj: key_name(bucket_name, key)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Jetstream.MixProject do
   use Mix.Project
 
-  @version "0.0.6"
+  @version "0.0.7"
   @github "https://github.com/mmmries/jetstream"
 
   def project do

--- a/test/jetstream/api/kv_test.exs
+++ b/test/jetstream/api/kv_test.exs
@@ -42,6 +42,10 @@ defmodule Jetstream.API.KVTest do
     assert :ok = KV.delete_bucket(:gnat, "KEY_CREATE_TEST")
   end
 
+  test "create_key/4 returns error" do
+    assert {:error, :timeout} = KV.create_key(:gnat, "KEY_CREATE_TEST", "foo", "bar", timeout: 1)
+  end
+
   test "delete_key/3 deletes a key" do
     assert {:ok, _} = KV.create_bucket(:gnat, "KEY_DELETE_TEST")
     assert :ok = KV.create_key(:gnat, "KEY_DELETE_TEST", "foo", "bar")

--- a/test/jetstream/api/kv_test.exs
+++ b/test/jetstream/api/kv_test.exs
@@ -46,16 +46,24 @@ defmodule Jetstream.API.KVTest do
     assert {:ok, _} = KV.create_bucket(:gnat, "KEY_DELETE_TEST")
     assert :ok = KV.create_key(:gnat, "KEY_DELETE_TEST", "foo", "bar")
     assert :ok = KV.delete_key(:gnat, "KEY_DELETE_TEST", "foo")
-    refute KV.get_value(:gnat, "KEY_DELETE_TEST", "foo")
+    assert KV.get_value(:gnat, "KEY_DELETE_TEST", "foo") == nil
     assert :ok = KV.delete_bucket(:gnat, "KEY_DELETE_TEST")
+  end
+
+  test "delete_key/3 returns error" do
+    assert {:error, :timeout} = KV.delete_key(:gnat, "KEY_DELETE_TEST", "foo", timeout: 1)
   end
 
   test "purge_key/3 purges a key" do
     assert {:ok, _} = KV.create_bucket(:gnat, "KEY_PURGE_TEST")
     assert :ok = KV.create_key(:gnat, "KEY_PURGE_TEST", "foo", "bar")
     assert :ok = KV.purge_key(:gnat, "KEY_PURGE_TEST", "foo")
-    refute KV.get_value(:gnat, "KEY_PURGE_TEST", "foo")
+    assert KV.get_value(:gnat, "KEY_PURGE_TEST", "foo") == nil
     assert :ok = KV.delete_bucket(:gnat, "KEY_PURGE_TEST")
+  end
+
+  test "purge_key/3 returns error" do
+    assert {:error, :timeout} = KV.purge_key(:gnat, "KEY_PURGE_TEST", "foo", timeout: 1)
   end
 
   test "put_value/4 updates a key" do

--- a/test/jetstream/api/kv_test.exs
+++ b/test/jetstream/api/kv_test.exs
@@ -74,6 +74,10 @@ defmodule Jetstream.API.KVTest do
     assert :ok = KV.delete_bucket(:gnat, "KEY_PUT_TEST")
   end
 
+  test "put_value/4 returns error" do
+    assert {:error, :timeout} = KV.put_value(:gnat, "KEY_PUT_TEST", "foo", "baz", timeout: 1)
+  end
+
   describe "watch/3" do
     setup do
       bucket = "KEY_WATCH_TEST"


### PR DESCRIPTION
I was finding race conditions that were creating flaky tests because some of these functions were async. Changed `KV.put_value`, `KV.create_key`, `KV.delete_key`, and `KV.purge_key` to be sync by waiting for a reply. 