### PR TITLE
Add support for using the ObjectStore pattern

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
         pair:
           - otp: "24.3.4"
             elixir: "1.12"
-            nats: "2.2.0"
+            nats: "2.3.0"
 
           - otp: "24.3.4"
             elixir: "main"

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ jetstream-*.tar
 
 # ASDF tool versions
 .tool-versions
+
+# tmp directory to test files
+tmp

--- a/lib/jetstream/api/object.ex
+++ b/lib/jetstream/api/object.ex
@@ -1,0 +1,61 @@
+defmodule Jetstream.API.Object do
+  @moduledoc """
+  API for interacting with the JetStream Object Store
+
+  Learn more about Object Store: https://docs.nats.io/nats-concepts/jetstream/obj_store
+  """
+  alias Jetstream.API.{Stream}
+
+  @stream_prefix "OBJ_"
+  @subject_prefix "$O."
+
+  def create_bucket(conn, bucket_name, params \\ []) do
+    stream = %Stream{
+      name: stream_name(bucket_name),
+      subjects: stream_subjects(bucket_name),
+      description: Keyword.get(params, :description),
+      max_msgs_per_subject: Keyword.get(params, :history, 1),
+      discard: :new,
+      deny_delete: true,
+      allow_rollup_hdrs: true,
+      max_age: Keyword.get(params, :ttl, 0),
+      max_bytes: Keyword.get(params, :max_bucket_size, -1),
+      max_msg_size: Keyword.get(params, :max_value_size, -1),
+      num_replicas: Keyword.get(params, :replicas, 1),
+      storage: Keyword.get(params, :storage, :file),
+      placement: Keyword.get(params, :placement),
+      duplicate_window: adjust_duplicate_window(Keyword.get(params, :ttl, 0))
+    }
+
+    Stream.create(conn, stream)
+  end
+
+  def delete_bucket(conn, bucket_name) do
+    Stream.delete(conn, stream_name(bucket_name))
+  end
+
+  defp stream_name(bucket_name) do
+    "#{@stream_prefix}#{bucket_name}"
+  end
+
+  defp stream_subjects(bucket_name) do
+    [
+      chunk_stream_subject(bucket_name),
+      meta_stream_subject(bucket_name)
+    ]
+  end
+
+  defp chunk_stream_subject(bucket_name) do
+    "#{@subject_prefix}#{bucket_name}.C.>"
+  end
+
+  defp meta_stream_subject(bucket_name) do
+    "#{@subject_prefix}#{bucket_name}.M.>"
+  end
+
+  @two_minutes_in_nanoseconds 1_200_000_000
+  # The `duplicate_window` can't be greater than the `max_age`. The default `duplicate_window`
+  # is 2 minutes. We'll keep the 2 minute window UNLESS the ttl is less than 2 minutes
+  defp adjust_duplicate_window(ttl) when ttl > 0 and ttl < @two_minutes_in_nanoseconds, do: ttl
+  defp adjust_duplicate_window(_ttl), do: @two_minutes_in_nanoseconds
+end

--- a/lib/jetstream/api/object.ex
+++ b/lib/jetstream/api/object.ex
@@ -16,9 +16,7 @@ defmodule Jetstream.API.Object do
         name: stream_name(bucket_name),
         subjects: stream_subjects(bucket_name),
         description: Keyword.get(params, :description),
-        max_msgs_per_subject: Keyword.get(params, :history, 1),
         discard: :new,
-        deny_delete: true,
         allow_rollup_hdrs: true,
         max_age: Keyword.get(params, :ttl, 0),
         max_bytes: Keyword.get(params, :max_bucket_size, -1),
@@ -35,6 +33,29 @@ defmodule Jetstream.API.Object do
 
   def delete_bucket(conn, bucket_name) do
     Stream.delete(conn, stream_name(bucket_name))
+  end
+
+  def get_object(conn, bucket_name, object_name, chunk_fun) do
+    with {:ok, %{config: _stream}} <- Stream.info(conn, stream_name(bucket_name)),
+         {:ok, meta} <- info(conn, bucket_name, object_name) do
+      receive_chunks(conn, meta, chunk_fun)
+    end
+  end
+
+  def info(conn, bucket_name, object_name) do
+    with {:ok, _stream_info} <- Stream.info(conn, stream_name(bucket_name)) do
+      Stream.get_message(conn, stream_name(bucket_name), %{
+        last_by_subj: meta_stream_topic(bucket_name, object_name)
+      })
+      |> case do
+        {:ok, message} ->
+          meta = json_to_meta(message.data)
+          {:ok, meta}
+
+        error ->
+          error
+      end
+    end
   end
 
   def list_objects(conn, bucket_name) do
@@ -60,22 +81,6 @@ defmodule Jetstream.API.Object do
     end
   end
 
-  def info(conn, bucket_name, object_name) do
-    with {:ok, _stream_info} <- Stream.info(conn, stream_name(bucket_name)) do
-      Stream.get_message(conn, stream_name(bucket_name), %{
-        last_by_subj: meta_stream_topic(bucket_name, object_name)
-      })
-      |> case do
-        {:ok, message} ->
-          meta = json_to_meta(message.data)
-          {:ok, meta}
-
-        error ->
-          error
-      end
-    end
-  end
-
   @spec put_object(Gnat.t(), String.t(), String.t(), File.io_device()) ::
           {:ok, map()} | {:error, any()}
   def put_object(conn, bucket_name, object_name, io) do
@@ -90,7 +95,7 @@ defmodule Jetstream.API.Object do
         nuid: nuid,
         size: size,
         chunks: chunks,
-        digest: "SHA-256=#{Base.encode64(digest)}"
+        digest: "SHA-256=#{Base.url_encode64(digest)}"
       }
 
       topic = meta_stream_topic(bucket_name, object_name)
@@ -125,12 +130,16 @@ defmodule Jetstream.API.Object do
     "#{@subject_prefix}#{bucket_name}.C.#{nuid}"
   end
 
+  defp chunk_stream_topic(%Meta{bucket: bucket, nuid: nuid}) do
+    "#{@subject_prefix}#{bucket}.C.#{nuid}"
+  end
+
   defp meta_stream_subject(bucket_name) do
     "#{@subject_prefix}#{bucket_name}.M.>"
   end
 
   defp meta_stream_topic(bucket_name, object_name) do
-    key = Base.encode64(object_name)
+    key = Base.url_encode64(object_name)
     "#{@subject_prefix}#{bucket_name}.M.#{key}"
   end
 
@@ -171,6 +180,45 @@ defmodule Jetstream.API.Object do
       {:msg, %{sid: ^sid, body: body}} ->
         meta = json_to_meta(body)
         receive_all_metas(sid, remaining - 1, [meta | messages])
+    after
+      10_000 ->
+        {:error, :timeout_waiting_for_messages}
+    end
+  end
+
+  defp receive_chunks(conn, %Meta{} = meta, chunk_fun) do
+    topic = chunk_stream_topic(meta)
+    stream = stream_name(meta.bucket)
+    inbox = Util.reply_inbox()
+    {:ok, sub} = Gnat.sub(conn, self(), inbox)
+
+    {:ok, consumer} =
+      Consumer.create(conn, %Consumer{
+        stream_name: stream,
+        deliver_subject: inbox,
+        deliver_policy: :all,
+        filter_subject: topic,
+        ack_policy: :none,
+        max_ack_pending: nil,
+        replay_policy: :instant,
+        max_deliver: 1
+      })
+
+    :ok = receive_chunks(sub, meta.chunks, chunk_fun)
+
+    :ok = Gnat.unsub(conn, sub)
+    :ok = Consumer.delete(conn, stream, consumer.name)
+  end
+
+  defp receive_chunks(_sub, 0, _chunk_fun) do
+    :ok
+  end
+
+  defp receive_chunks(sub, remaining, chunk_fun) do
+    receive do
+      {:msg, %{sid: ^sub, body: body}} ->
+        chunk_fun.(body)
+        receive_chunks(sub, remaining - 1, chunk_fun)
     after
       10_000 ->
         {:error, :timeout_waiting_for_messages}

--- a/lib/jetstream/api/object.ex
+++ b/lib/jetstream/api/object.ex
@@ -4,7 +4,7 @@ defmodule Jetstream.API.Object do
 
   Learn more about Object Store: https://docs.nats.io/nats-concepts/jetstream/obj_store
   """
-  alias Jetstream.API.{Stream}
+  alias Jetstream.API.{Stream, Util}
 
   @stream_prefix "OBJ_"
   @subject_prefix "$O."
@@ -36,6 +36,36 @@ defmodule Jetstream.API.Object do
     Stream.delete(conn, stream_name(bucket_name))
   end
 
+  @spec put_object(Gnat.t(), String.t(), String.t(), File.io_device()) ::
+          {:ok, map()} | {:error, any()}
+  def put_object(conn, bucket_name, object_name, io) do
+    nuid = Util.nuid()
+    chunk_topic = chunk_stream_topic(bucket_name, nuid)
+
+    with {:ok, %{config: _stream}} <- Stream.info(conn, stream_name(bucket_name)),
+         {:ok, chunks, size, digest} <- send_chunks(conn, io, chunk_topic) do
+      object_meta = %{
+        name: object_name,
+        bucket: bucket_name,
+        nuid: nuid,
+        size: size,
+        chunks: chunks,
+        digest: "SHA-256=#{Base.encode64(digest)}"
+      }
+
+      topic = meta_stream_topic(bucket_name, object_name)
+      body = Jason.encode!(object_meta)
+
+      case Gnat.request(conn, topic, body, headers: [{"Nats-Rollup", "sub"}]) do
+        {:ok, _} ->
+          {:ok, object_meta}
+
+        error ->
+          error
+      end
+    end
+  end
+
   defp stream_name(bucket_name) do
     "#{@stream_prefix}#{bucket_name}"
   end
@@ -51,8 +81,17 @@ defmodule Jetstream.API.Object do
     "#{@subject_prefix}#{bucket_name}.C.>"
   end
 
+  defp chunk_stream_topic(bucket_name, nuid) do
+    "#{@subject_prefix}#{bucket_name}.C.#{nuid}"
+  end
+
   defp meta_stream_subject(bucket_name) do
     "#{@subject_prefix}#{bucket_name}.M.>"
+  end
+
+  defp meta_stream_topic(bucket_name, object_name) do
+    key = Base.encode64(object_name)
+    "#{@subject_prefix}#{bucket_name}.M.#{key}"
   end
 
   @two_minutes_in_nanoseconds 1_200_000_000
@@ -60,6 +99,38 @@ defmodule Jetstream.API.Object do
   # is 2 minutes. We'll keep the 2 minute window UNLESS the ttl is less than 2 minutes
   defp adjust_duplicate_window(ttl) when ttl > 0 and ttl < @two_minutes_in_nanoseconds, do: ttl
   defp adjust_duplicate_window(_ttl), do: @two_minutes_in_nanoseconds
+
+  @chunk_size 128 * 1024
+  defp send_chunks(conn, io, topic) do
+    sha = :crypto.hash_init(:sha256)
+    size = 0
+    chunks = 0
+    send_chunks(conn, io, topic, sha, size, chunks)
+  end
+
+  defp send_chunks(conn, io, topic, sha, size, chunks) do
+    case IO.binread(io, @chunk_size) do
+      :eof ->
+        sha = :crypto.hash_final(sha)
+        {:ok, chunks, size, sha}
+
+      {:error, err} ->
+        {:error, err}
+
+      bytes ->
+        sha = :crypto.hash_update(sha, bytes)
+        size = size + byte_size(bytes)
+        chunks = chunks + 1
+
+        case Gnat.request(conn, topic, bytes) do
+          {:ok, _} ->
+            send_chunks(conn, io, topic, sha, size, chunks)
+
+          error ->
+            error
+        end
+    end
+  end
 
   defp validate_bucket_name(name) do
     case Regex.match?(~r/^[a-zA-Z0-9_-]+$/, name) do

--- a/lib/jetstream/api/object.ex
+++ b/lib/jetstream/api/object.ex
@@ -10,14 +10,16 @@ defmodule Jetstream.API.Object do
   @stream_prefix "OBJ_"
   @subject_prefix "$O."
 
-  @type bucket_opt :: {:description, String.t()}
-                    | {:max_bucket_size, integer()}
-                    | {:max_chunk_size, integer()}
-                    | {:placement, Stream.placement()}
-                    | {:replicas, non_neg_integer()}
-                    | {:storage, :file | :memory}
-                    | {:ttl, non_neg_integer()}
-  @spec create_bucket(Gnat.t(), String.t(), list(bucket_opt)) :: {:ok, Stream.info()} | {:error, any()}
+  @type bucket_opt ::
+          {:description, String.t()}
+          | {:max_bucket_size, integer()}
+          | {:max_chunk_size, integer()}
+          | {:placement, Stream.placement()}
+          | {:replicas, non_neg_integer()}
+          | {:storage, :file | :memory}
+          | {:ttl, non_neg_integer()}
+  @spec create_bucket(Gnat.t(), String.t(), list(bucket_opt)) ::
+          {:ok, Stream.info()} | {:error, any()}
   def create_bucket(conn, bucket_name, params \\ []) do
     with :ok <- validate_bucket_name(bucket_name) do
       stream = %Stream{

--- a/lib/jetstream/api/object/meta.ex
+++ b/lib/jetstream/api/object/meta.ex
@@ -1,0 +1,5 @@
+defmodule Jetstream.API.Object.Meta do
+  @derive Jason.Encoder
+  @enforce_keys [:bucket, :chunks, :digest, :name, :nuid, :size]
+  defstruct [:bucket, :chunks, :digest, :name, :nuid, :size]
+end

--- a/lib/jetstream/api/object/meta.ex
+++ b/lib/jetstream/api/object/meta.ex
@@ -1,5 +1,4 @@
 defmodule Jetstream.API.Object.Meta do
-  @derive Jason.Encoder
   @enforce_keys [:bucket, :chunks, :digest, :name, :nuid, :size]
   defstruct bucket: nil,
             chunks: nil,

--- a/lib/jetstream/api/object/meta.ex
+++ b/lib/jetstream/api/object/meta.ex
@@ -1,5 +1,25 @@
 defmodule Jetstream.API.Object.Meta do
   @derive Jason.Encoder
   @enforce_keys [:bucket, :chunks, :digest, :name, :nuid, :size]
-  defstruct [:bucket, :chunks, :digest, :name, :nuid, :size]
+  defstruct bucket: nil,
+            chunks: nil,
+            deleted: false,
+            digest: nil,
+            name: nil,
+            nuid: nil,
+            size: nil
+end
+
+defimpl Jason.Encoder, for: Jetstream.API.Object.Meta do
+  alias Jetstream.API.Object.Meta
+
+  def encode(%Meta{deleted: true} = meta, opts) do
+    Map.take(meta, [:bucket, :chunks, :deleted, :digest, :name, :nuid, :size])
+    |> Jason.Encode.map(opts)
+  end
+
+  def encode(meta, opts) do
+    Map.take(meta, [:bucket, :chunks, :digest, :name, :nuid, :size])
+    |> Jason.Encode.map(opts)
+  end
 end

--- a/lib/jetstream/api/object/meta.ex
+++ b/lib/jetstream/api/object/meta.ex
@@ -8,6 +8,16 @@ defmodule Jetstream.API.Object.Meta do
             name: nil,
             nuid: nil,
             size: nil
+
+  @type t :: %__MODULE__{
+          bucket: String.t(),
+          chunks: non_neg_integer(),
+          deleted: boolean(),
+          digest: String.t(),
+          name: String.t(),
+          nuid: String.t(),
+          size: non_neg_integer()
+        }
 end
 
 defimpl Jason.Encoder, for: Jetstream.API.Object.Meta do

--- a/lib/jetstream/api/stream.ex
+++ b/lib/jetstream/api/stream.ex
@@ -333,7 +333,8 @@ defmodule Jetstream.API.Stream do
       :ok
 
   """
-  @spec purge(conn :: Gnat.t(), stream_name :: binary()) :: :ok | {:error, any()}
+  @type method :: %{filter: String.t()}
+  @spec purge(conn :: Gnat.t(), stream_name :: binary(), method) :: :ok | {:error, any()}
   def purge(conn, stream_name, method) when is_binary(stream_name) do
     with :ok <- validate_purge_method(method),
          body <- Jason.encode!(method),

--- a/lib/jetstream/api/stream.ex
+++ b/lib/jetstream/api/stream.ex
@@ -324,6 +324,25 @@ defmodule Jetstream.API.Stream do
   end
 
   @doc """
+  Purges some of the messages in a stream.
+
+  ## Examples
+
+      iex> Jetstream.API.Stream.create(:gnat, %Jetstream.API.Stream{name: "stream", subjects: ["sub1", "sub2"]})
+      iex> Jetstream.API.Stream.purge(:gnat, "stream", %{filter: "sub1"})
+      :ok
+
+  """
+  @spec purge(conn :: Gnat.t(), stream_name :: binary()) :: :ok | {:error, any()}
+  def purge(conn, stream_name, method) when is_binary(stream_name) do
+    with :ok <- validate_purge_method(method),
+         body <- Jason.encode!(method),
+         {:ok, _response} <- request(conn, "$JS.API.STREAM.PURGE.#{stream_name}", body) do
+      :ok
+    end
+  end
+
+  @doc """
   Information about config and state of a Stream.
 
   ## Examples
@@ -486,5 +505,13 @@ defmodule Jetstream.API.Stream do
     else
       {:error, "To get a message you must use only one of `seq` or `last_by_subj`"}
     end
+  end
+
+  defp validate_purge_method(%{filter: subject}) when is_binary(subject) do
+    :ok
+  end
+
+  defp validate_purge_method(_) do
+    {:error, "When purging, you must pass a %{filter: subject}"}
   end
 end

--- a/test/jetstream/api/object_test.exs
+++ b/test/jetstream/api/object_test.exs
@@ -37,6 +37,37 @@ defmodule Jetstream.API.ObjectTest do
     end
   end
 
+  describe "get_object/4" do
+    test "retrieves and object chunk-by-chunk" do
+      nuid = Jetstream.API.Util.nuid()
+      assert {:ok, _} = Object.create_bucket(:gnat, nuid)
+      readme_content = File.read!(@readme_path)
+      assert {:ok, _meta} = put_filepath(@readme_path, nuid, "README.md")
+
+      Object.get_object(:gnat, nuid, "README.md", fn chunk ->
+        assert chunk == readme_content
+        send(self(), :got_chunk)
+      end)
+
+      assert_received :got_chunk
+
+      Object.delete_bucket(:gnat, nuid)
+    end
+  end
+
+  describe "info/3" do
+    test "lookup meta information about an object" do
+      assert {:ok, %{config: _stream}} = Object.create_bucket(:gnat, "INF")
+      assert {:ok, io} = File.open(@readme_path, [:read])
+      assert {:ok, initial_meta} = Object.put_object(:gnat, "INF", "README.md", io)
+
+      assert {:ok, lookup_meta} = Object.info(:gnat, "INF", "README.md")
+      assert lookup_meta == initial_meta
+
+      assert :ok = Object.delete_bucket(:gnat, "INF")
+    end
+  end
+
   describe "list_objects/3" do
     test "list an empty bucket" do
       bucket = nuid()
@@ -60,39 +91,75 @@ defmodule Jetstream.API.ObjectTest do
     end
   end
 
-  describe "info/3" do
-    test "lookup meta information about an object" do
-      assert {:ok, %{config: _stream}} = Object.create_bucket(:gnat, "INF")
-      assert {:ok, io} = File.open(@readme_path, [:read])
-      assert {:ok, initial_meta} = Object.put_object(:gnat, "INF", "README.md", io)
-
-      assert {:ok, lookup_meta} = Object.info(:gnat, "INF", "README.md")
-      assert lookup_meta == initial_meta
-
-      assert :ok = Object.delete_bucket(:gnat, "INF")
-    end
-  end
-
   describe "put_object/4" do
     test "creates an object" do
-      {:ok, bytes} = File.read(@readme_path)
-      sha = :crypto.hash(:sha256, bytes)
-      assert {:ok, io} = File.open(@readme_path, [:read])
-
       assert {:ok, %{config: _stream}} = Object.create_bucket(:gnat, "MY-STORE")
-      assert {:ok, object_meta} = Object.put_object(:gnat, "MY-STORE", "README.md", io)
+
+      expected_sha = @readme_path |> File.read!() |> then(&:crypto.hash(:sha256, &1))
+      assert {:ok, object_meta} = put_filepath(@readme_path, "MY-STORE", "README.md")
       assert object_meta.name == "README.md"
       assert object_meta.bucket == "MY-STORE"
       assert object_meta.chunks == 1
       assert "SHA-256=" <> encoded = object_meta.digest
-      assert Base.decode64!(encoded) == sha
+      assert Base.url_decode64!(encoded) == expected_sha
+
       assert :ok = Object.delete_bucket(:gnat, "MY-STORE")
     end
 
     test "return an error if the object store doesn't exist" do
-      assert {:ok, io} = File.open(@readme_path, [:read])
-      assert {:error, err} = Object.put_object(:gnat, "I_DONT_EXIST", "foo", io)
+      assert {:error, err} = put_filepath(@readme_path, "I_DONT_EXIST", "foo")
       assert %{"code" => 404, "description" => "stream not found"} = err
     end
+  end
+
+  test "storing and retrieving larger files" do
+    assert {:ok, path, sha} = generate_big_file()
+    bucket = nuid()
+    assert {:ok, %{config: _stream}} = Object.create_bucket(:gnat, bucket)
+    assert {:ok, meta} = put_filepath(path, bucket, "big")
+    assert meta.chunks == 16
+    assert meta.size == 16 * 128 * 1024
+    assert "SHA-256=" <> encoded = meta.digest
+    assert Base.url_decode64!(encoded) == sha
+
+    Process.put(:buffer, "")
+
+    Object.get_object(:gnat, bucket, "big", fn chunk ->
+      Process.put(:buffer, Process.get(:buffer) <> chunk)
+    end)
+
+    file_contents = Process.get(:buffer)
+
+    assert byte_size(file_contents) == meta.size
+    assert :crypto.hash(:sha256, file_contents) == sha
+    assert :ok = Object.delete_bucket(:gnat, bucket)
+  end
+
+  # create a random 2MB binary file
+  # re-use it on subsequent test runs if it already exists
+  defp generate_big_file do
+    filepath = Path.join("tmp", "big_file.bin")
+
+    if File.exists?(filepath) do
+      content = File.read!(filepath)
+      sha = :crypto.hash(:sha256, content)
+      {:ok, filepath, sha}
+    else
+      {:ok, _} =
+        File.open(filepath, [:write], fn fh ->
+          Enum.each(1..16, fn _ ->
+            rand_chunk = :crypto.strong_rand_bytes(128) |> String.duplicate(1024)
+
+            :ok = IO.binwrite(fh, rand_chunk)
+          end)
+        end)
+
+      generate_big_file()
+    end
+  end
+
+  defp put_filepath(path, bucket, name) do
+    {:ok, io} = File.open(path, [:read])
+    Object.put_object(:gnat, bucket, name, io)
   end
 end

--- a/test/jetstream/api/object_test.exs
+++ b/test/jetstream/api/object_test.exs
@@ -4,6 +4,7 @@ defmodule Jetstream.API.ObjectTest do
   import Jetstream.API.Util, only: [nuid: 0]
 
   @moduletag with_gnat: :gnat
+  @changelog_path Path.join([Path.dirname(__DIR__), "..", "..", "CHANGELOG.md"])
   @readme_path Path.join([Path.dirname(__DIR__), "..", "..", "README.md"])
 
   describe "create_bucket/3" do
@@ -21,6 +22,15 @@ defmodule Jetstream.API.ObjectTest do
              ]
 
       assert :ok = Object.delete_bucket(:gnat, "MY-STORE")
+    end
+
+    test "creating a bucket with TTL" do
+      bucket = nuid()
+      ttl = 10 * 1_000_000_000 # 10s in nanoseconds
+      assert {:ok, %{config: config}} = Object.create_bucket(:gnat, bucket, ttl: ttl)
+      assert config.max_age == ttl
+
+      assert :ok = Object.delete_bucket(:gnat, bucket)
     end
 
     test "bucket names are validated" do
@@ -128,6 +138,18 @@ defmodule Jetstream.API.ObjectTest do
       assert :ok = Object.delete_bucket(:gnat, "MY-STORE")
     end
 
+    test "overwriting a file" do
+      bucket = nuid()
+      assert {:ok, %{config: _stream}} = Object.create_bucket(:gnat, bucket)
+      assert {:ok, _} = put_filepath(@readme_path, bucket, "WAT")
+      size_after_readme = stream_byte_size(bucket)
+      assert {:ok, _} = put_filepath(@changelog_path, bucket, "WAT")
+      size_after_changelog = stream_byte_size(bucket)
+      assert size_after_changelog < size_after_readme
+      assert {:ok, [meta]} = Object.list_objects(:gnat, bucket)
+      assert meta.name == "WAT"
+    end
+
     test "return an error if the object store doesn't exist" do
       assert {:error, err} = put_filepath(@readme_path, "I_DONT_EXIST", "foo")
       assert %{"code" => 404, "description" => "stream not found"} = err
@@ -150,17 +172,13 @@ defmodule Jetstream.API.ObjectTest do
       Process.put(:buffer, Process.get(:buffer) <> chunk)
     end)
 
-    {:ok, %{state: state}} = Stream.info(:gnat, "OBJ_#{bucket}")
-    assert state.bytes > 2 * 1024 * 1024
-
     file_contents = Process.get(:buffer)
-
     assert byte_size(file_contents) == meta.size
     assert :crypto.hash(:sha256, file_contents) == sha
+    assert stream_byte_size(bucket) > 2 * 1024 * 1024
 
     assert :ok = Object.delete_object(:gnat, bucket, "big")
-    {:ok, %{state: state}} = Stream.info(:gnat, "OBJ_#{bucket}")
-    assert state.bytes < 1024
+    assert stream_byte_size(bucket) < 1024
     :ok = Object.delete_bucket(:gnat, bucket)
   end
 
@@ -190,5 +208,10 @@ defmodule Jetstream.API.ObjectTest do
   defp put_filepath(path, bucket, name) do
     {:ok, io} = File.open(path, [:read])
     Object.put_object(:gnat, bucket, name, io)
+  end
+
+  defp stream_byte_size(bucket) do
+    {:ok, %{state: state}} = Stream.info(:gnat, "OBJ_#{bucket}")
+    state.bytes
   end
 end

--- a/test/jetstream/api/object_test.exs
+++ b/test/jetstream/api/object_test.exs
@@ -1,0 +1,24 @@
+defmodule Jetstream.API.ObjectTest do
+  use Jetstream.ConnCase, min_server_version: "2.6.2"
+  alias Jetstream.API.Object
+
+  @moduletag with_gnat: :gnat
+
+  describe "create_bucket/3" do
+    test "create/delete a bucket" do
+      assert {:ok, %{config: config}} = Object.create_bucket(:gnat, "MY-STORE")
+      assert config.name == "OBJ_MY-STORE"
+      assert config.max_age == 0
+      assert config.max_bytes == -1
+      assert config.storage == :file
+      assert config.allow_rollup_hdrs == true
+
+      assert config.subjects == [
+               "$O.MY-STORE.C.>",
+               "$O.MY-STORE.M.>"
+             ]
+
+      assert :ok = Object.delete_bucket(:gnat, "MY-STORE")
+    end
+  end
+end

--- a/test/jetstream/api/object_test.exs
+++ b/test/jetstream/api/object_test.exs
@@ -3,6 +3,7 @@ defmodule Jetstream.API.ObjectTest do
   alias Jetstream.API.Object
 
   @moduletag with_gnat: :gnat
+  @readme_path Path.join([Path.dirname(__DIR__), "..", "..", "README.md"])
 
   describe "create_bucket/3" do
     test "create/delete a bucket" do
@@ -25,6 +26,29 @@ defmodule Jetstream.API.ObjectTest do
       assert {:error, "invalid bucket name"} = Object.create_bucket(:gnat, "")
       assert {:error, "invalid bucket name"} = Object.create_bucket(:gnat, "MY.STORE")
       assert {:error, "invalid bucket name"} = Object.create_bucket(:gnat, "(*!&@($%*&))")
+    end
+  end
+
+  describe "put_object/4" do
+    test "creates an object" do
+      {:ok, bytes} = File.read(@readme_path)
+      sha = :crypto.hash(:sha256, bytes)
+      assert {:ok, io} = File.open(@readme_path, [:read])
+
+      assert {:ok, %{config: _stream}} = Object.create_bucket(:gnat, "MY-STORE")
+      assert {:ok, object_meta} = Object.put_object(:gnat, "MY-STORE", "README.md", io)
+      assert object_meta.name == "README.md"
+      assert object_meta.bucket == "MY-STORE"
+      assert object_meta.chunks == 1
+      assert "SHA-256=" <> encoded = object_meta.digest
+      assert Base.decode64!(encoded) == sha
+      assert :ok = Object.delete_bucket(:gnat, "MY-STORE")
+    end
+
+    test "return an error if the object store doesn't exist" do
+      assert {:ok, io} = File.open(@readme_path, [:read])
+      assert {:error, err} = Object.put_object(:gnat, "I_DONT_EXIST", "foo", io)
+      assert %{"code" => 404, "description" => "stream not found"} = err
     end
   end
 end

--- a/test/jetstream/api/object_test.exs
+++ b/test/jetstream/api/object_test.exs
@@ -26,7 +26,8 @@ defmodule Jetstream.API.ObjectTest do
 
     test "creating a bucket with TTL" do
       bucket = nuid()
-      ttl = 10 * 1_000_000_000 # 10s in nanoseconds
+      # 10s in nanoseconds
+      ttl = 10 * 1_000_000_000
       assert {:ok, %{config: config}} = Object.create_bucket(:gnat, bucket, ttl: ttl)
       assert config.max_age == ttl
 

--- a/test/jetstream/api/object_test.exs
+++ b/test/jetstream/api/object_test.exs
@@ -20,5 +20,11 @@ defmodule Jetstream.API.ObjectTest do
 
       assert :ok = Object.delete_bucket(:gnat, "MY-STORE")
     end
+
+    test "bucket names are validated" do
+      assert {:error, "invalid bucket name"} = Object.create_bucket(:gnat, "")
+      assert {:error, "invalid bucket name"} = Object.create_bucket(:gnat, "MY.STORE")
+      assert {:error, "invalid bucket name"} = Object.create_bucket(:gnat, "(*!&@($%*&))")
+    end
   end
 end


### PR DESCRIPTION
Coneptual documentation: https://docs.nats.io/nats-concepts/jetstream/obj_store/obj_walkthrough
ADR: https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-20.md

Similar to the Key-Value functionality, this is not actually a specific thing built into the nats-server, but a documented pattern for how to store chunked files. This allows for efficient storage/streaming of larger files. I'll be modeling my changes from the ADR notes as well as the time-honored tradition of doing `nats-server -js -DV` and reverse engineering the logs that are generated when using the `nats` command-line tool for creating buckets, storing objects, retrieving objects, etc.

I'm going to start a checklist of functionality I want to cover before we merge/release this API

- [x] create a bucket
- [x] validate bucket names before creating
- [x] put a file in a bucket
- [x] overwrite a file in a bucket (cleanup prior chunks)
- [x] put a file in a bucket with TTL
- [x] get a file from a bucket (provide a callback function to accept each chunk)
- [x] delete a file from a bucket
- [x] list the files in a bucket