### PR TITLE
add ability to list files

### DIFF
--- a/lib/jetstream/api/object.ex
+++ b/lib/jetstream/api/object.ex
@@ -60,6 +60,22 @@ defmodule Jetstream.API.Object do
     end
   end
 
+
+  def info(conn, bucket_name, object_name) do
+    with {:ok, _stream_info} <- Stream.info(conn, stream_name(bucket_name)) do
+      Stream.get_message(conn, stream_name(bucket_name), %{
+        last_by_subj: meta_stream_topic(bucket_name, object_name)
+      })
+      |> case do
+        {:ok, message} ->
+          {:ok, message}
+
+        error ->
+          error
+      end
+    end
+  end
+
   @spec put_object(Gnat.t(), String.t(), String.t(), File.io_device()) ::
           {:ok, map()} | {:error, any()}
   def put_object(conn, bucket_name, object_name, io) do

--- a/lib/jetstream/api/object/meta.ex
+++ b/lib/jetstream/api/object/meta.ex
@@ -1,0 +1,4 @@
+defmodule Jetstream.API.Object.Meta do
+  @enforce_keys [:bucket, :chunks, :digest, :name, :nuid, :size]
+  defstruct [:bucket, :chunks, :digest, :name, :nuid, :size]
+end

--- a/lib/jetstream/api/object/meta.ex
+++ b/lib/jetstream/api/object/meta.ex
@@ -1,4 +1,5 @@
 defmodule Jetstream.API.Object.Meta do
+  @derive Jason.Encoder
   @enforce_keys [:bucket, :chunks, :digest, :name, :nuid, :size]
   defstruct [:bucket, :chunks, :digest, :name, :nuid, :size]
 end

--- a/test/jetstream/api/object_test.exs
+++ b/test/jetstream/api/object_test.exs
@@ -1,6 +1,7 @@
 defmodule Jetstream.API.ObjectTest do
   use Jetstream.ConnCase, min_server_version: "2.6.2"
   alias Jetstream.API.Object
+  import Jetstream.API.Util, only: [nuid: 0]
 
   @moduletag with_gnat: :gnat
   @readme_path Path.join([Path.dirname(__DIR__), "..", "..", "README.md"])
@@ -38,20 +39,20 @@ defmodule Jetstream.API.ObjectTest do
 
   describe "list_objects/3" do
     test "list an empty bucket" do
-      nuid = Jetstream.API.Util.nuid()
-      assert {:ok, %{config: _config}} = Object.create_bucket(:gnat, nuid)
-      assert {:ok, []} = Object.list_objects(:gnat, nuid)
+      bucket = nuid()
+      assert {:ok, %{config: _config}} = Object.create_bucket(:gnat, bucket)
+      assert {:ok, []} = Object.list_objects(:gnat, bucket)
     end
 
     test "list a bucket with two files" do
-      nuid = Jetstream.API.Util.nuid()
-      assert {:ok, %{config: _config}} = Object.create_bucket(:gnat, nuid)
+      bucket = nuid()
+      assert {:ok, %{config: _config}} = Object.create_bucket(:gnat, bucket)
       assert {:ok, io} = File.open(@readme_path, [:read])
-      assert {:ok, _object} = Object.put_object(:gnat, nuid, "README.md", io)
+      assert {:ok, _object} = Object.put_object(:gnat, bucket, "README.md", io)
       assert {:ok, io} = File.open(@readme_path, [:read])
-      assert {:ok, _object} = Object.put_object(:gnat, nuid, "SOMETHING.md", io)
+      assert {:ok, _object} = Object.put_object(:gnat, bucket, "SOMETHING.md", io)
 
-      assert {:ok, objects} = Object.list_objects(:gnat, nuid)
+      assert {:ok, objects} = Object.list_objects(:gnat, bucket)
       [readme, something] = Enum.sort_by(objects, & &1.name)
       assert readme.name == "README.md"
       assert readme.size == something.size

--- a/test/jetstream/api/object_test.exs
+++ b/test/jetstream/api/object_test.exs
@@ -59,6 +59,19 @@ defmodule Jetstream.API.ObjectTest do
     end
   end
 
+  describe "info/3" do
+    test "lookup meta information about an object" do
+      assert {:ok, %{config: _stream}} = Object.create_bucket(:gnat, "INF")
+      assert {:ok, io} = File.open(@readme_path, [:read])
+      assert {:ok, initial_meta} = Object.put_object(:gnat, "INF", "README.md", io)
+
+      assert {:ok, lookup_meta} = Object.info(:gnat, "INF", "README.md")
+      assert lookup_meta == initial_meta
+
+      assert :ok = Object.delete_bucket(:gnat, "INF")
+    end
+  end
+
   describe "put_object/4" do
     test "creates an object" do
       {:ok, bytes} = File.read(@readme_path)


### PR DESCRIPTION
This is part of the https://github.com/mmmries/jetstream/pull/78 project and adds the ability to list files in a bucket.

We do this by creating an ephemeral consumer, and getting the number of pending message for that consumer, then translating each of those meta messages into a `Jetstream.API.Object.Meta` struct.

One thing that I haven't sorted out here is the [ModTime](https://github.com/nats-io/nats-architecture-and-design/blob/24afd7ee3c5270c3b56b67b78b7a0237988a2e6a/adr/ADR-20.md#modified-time). The ADR specifies that the ModTime shouldn't be persisted, but the client should use the time of the meta message being saved into jetstream as the modtime and return it to the user. With a PushConsumer, we only get the contents of each message, we don't get context data about which message sequence number it is, or the timestamp of when it was recorded.

Perhaps we should use a `PullConsumer` when we stream all of the meta messages? I hesitated to use the `PullConsumer` becuse it is currently implemented in a way that is designed for a supervision tree. But, that contextual data might be really useful?