### PR TITLE
support deleting an object from a bucket

### DIFF
--- a/lib/jetstream/api/object/meta.ex
+++ b/lib/jetstream/api/object/meta.ex
@@ -1,5 +1,25 @@
 defmodule Jetstream.API.Object.Meta do
   @derive Jason.Encoder
   @enforce_keys [:bucket, :chunks, :digest, :name, :nuid, :size]
-  defstruct [:bucket, :chunks, :digest, :name, :nuid, :size]
+  defstruct bucket: nil,
+            chunks: nil,
+            deleted: false,
+            digest: nil,
+            name: nil,
+            nuid: nil,
+            size: nil
+end
+
+defimpl Jason.Encoder, for: Jetstream.API.Object.Meta do
+  alias Jetstream.API.Object.Meta
+
+  def encode(%Meta{deleted: true} = meta, opts) do
+    Map.take(meta, [:bucket, :chunks, :deleted, :digest, :name, :nuid, :size])
+    |> Jason.Encode.map(opts)
+  end
+
+  def encode(meta, opts) do
+    Map.take(meta, [:bucket, :chunks, :digest, :name, :nuid, :size])
+    |> Jason.Encode.map(opts)
+  end
 end

--- a/lib/jetstream/api/stream.ex
+++ b/lib/jetstream/api/stream.ex
@@ -324,6 +324,25 @@ defmodule Jetstream.API.Stream do
   end
 
   @doc """
+  Purges some of the messages in a stream.
+
+  ## Examples
+
+      iex> Jetstream.API.Stream.create(:gnat, %Jetstream.API.Stream{name: "stream", subjects: ["sub1", "sub2"]})
+      iex> Jetstream.API.Stream.purge(:gnat, "stream", %{filter: "sub1"})
+      :ok
+
+  """
+  @spec purge(conn :: Gnat.t(), stream_name :: binary()) :: :ok | {:error, any()}
+  def purge(conn, stream_name, method) when is_binary(stream_name) do
+    with :ok <- validate_purge_method(method),
+         body <- Jason.encode!(method),
+         {:ok, _response} <- request(conn, "$JS.API.STREAM.PURGE.#{stream_name}", body) do
+      :ok
+    end
+  end
+
+  @doc """
   Information about config and state of a Stream.
 
   ## Examples
@@ -486,5 +505,13 @@ defmodule Jetstream.API.Stream do
     else
       {:error, "To get a message you must use only one of `seq` or `last_by_subj`"}
     end
+  end
+
+  defp validate_purge_method(%{filter: subject}) when is_binary(subject) do
+    :ok
+  end
+
+  defp validate_purge_method(_) do
+    {:error, "When purging, you must pass a %{filter: subject}"}
   end
 end


### PR DESCRIPTION
Add support for deleting objects from a bucket. I also went ahead and implemented the default behavior of ignoring deleted files when listing a bucket. This matches the go client behavior.