### PR TITLE
Add Jetstream domain support

### DIFF
--- a/lib/jetstream/api/consumer.ex
+++ b/lib/jetstream/api/consumer.ex
@@ -14,6 +14,7 @@ defmodule Jetstream.API.Consumer do
   Consumer struct fields explanation:
 
   * `:stream_name` - name of a stream the consumer is pointing at.
+  * `:domain` - JetStream domain the stream is on.
   * `:ack_policy` - how the messages should be acknowledged. It has the following options:
       - `:explicit` - the default policy. It means that each individual message must be acknowledged.
         It is the only allowed option for pull consumers.
@@ -92,6 +93,7 @@ defmodule Jetstream.API.Consumer do
     :deliver_group,
     :deliver_subject,
     :description,
+    :domain,
     :durable_name,
     :filter_subject,
     :flow_control,
@@ -116,6 +118,7 @@ defmodule Jetstream.API.Consumer do
 
   @type t :: %__MODULE__{
           stream_name: binary(),
+          domain: nil | binary(),
           ack_policy: :none | :all | :explicit,
           ack_wait: nil | non_neg_integer(),
           backoff: nil | [non_neg_integer()],
@@ -226,7 +229,7 @@ defmodule Jetstream.API.Consumer do
   """
   @spec create(conn :: Gnat.t(), consumer :: t()) :: {:ok, info()} | {:error, term()}
   def create(conn, %__MODULE__{durable_name: name} = consumer) when not is_nil(name) do
-    create_topic = "$JS.API.CONSUMER.DURABLE.CREATE.#{consumer.stream_name}.#{name}"
+    create_topic = "#{js_api(consumer.domain)}.CONSUMER.DURABLE.CREATE.#{consumer.stream_name}.#{name}"
 
     with :ok <- validate_durable(consumer),
          {:ok, raw_response} <- request(conn, create_topic, create_payload(consumer)) do
@@ -235,7 +238,7 @@ defmodule Jetstream.API.Consumer do
   end
 
   def create(conn, %__MODULE__{} = consumer) do
-    create_topic = "$JS.API.CONSUMER.CREATE.#{consumer.stream_name}"
+    create_topic = "#{js_api(consumer.domain)}.CONSUMER.CREATE.#{consumer.stream_name}"
 
     with :ok <- validate(consumer),
          {:ok, raw_response} <- request(conn, create_topic, create_payload(consumer)) do
@@ -256,10 +259,10 @@ defmodule Jetstream.API.Consumer do
       iex> {:error, %{"code" => 404, "description" => "stream not found"}} = Jetstream.API.Consumer.delete(:gnat, "wrong_stream", "consumer")
 
   """
-  @spec delete(conn :: Gnat.t(), stream_name :: binary(), consumer_name :: binary()) ::
+  @spec delete(conn :: Gnat.t(), stream_name :: binary(), consumer_name :: binary(), domain :: nil | binary()) ::
           :ok | {:error, any()}
-  def delete(conn, stream_name, consumer_name) do
-    topic = "$JS.API.CONSUMER.DELETE.#{stream_name}.#{consumer_name}"
+  def delete(conn, stream_name, consumer_name, domain \\ nil) do
+    topic = "#{js_api(domain)}.CONSUMER.DELETE.#{stream_name}.#{consumer_name}"
 
     with {:ok, _response} <- request(conn, topic, "") do
       :ok
@@ -278,10 +281,10 @@ defmodule Jetstream.API.Consumer do
       iex>  {:error, %{"code" => 404, "description" => "stream not found"}} = Jetstream.API.Consumer.info(:gnat, "wrong_stream", "consumer")
 
   """
-  @spec info(conn :: Gnat.t(), stream_name :: binary(), consumer_name :: binary()) ::
+  @spec info(conn :: Gnat.t(), stream_name :: binary(), consumer_name :: binary(), domain :: nil | binary()) ::
           {:ok, info()} | {:error, any()}
-  def info(conn, stream_name, consumer_name) do
-    topic = "$JS.API.CONSUMER.INFO.#{stream_name}.#{consumer_name}"
+  def info(conn, stream_name, consumer_name, domain \\ nil) do
+    topic = "#{js_api(domain)}.CONSUMER.INFO.#{stream_name}.#{consumer_name}"
 
     with {:ok, raw} <- request(conn, topic, "") do
       {:ok, to_info(raw)}
@@ -299,15 +302,15 @@ defmodule Jetstream.API.Consumer do
       iex> {:error, %{"code" => 404, "description" => "stream not found"}} = Jetstream.API.Consumer.list(:gnat, "wrong_stream")
 
   """
-  @spec list(conn :: Gnat.t(), stream_name :: binary(), params :: [offset: non_neg_integer()]) ::
+  @spec list(conn :: Gnat.t(), stream_name :: binary(), domain :: nil | binary(), params :: [offset: non_neg_integer()]) ::
           {:ok, consumers()} | {:error, term()}
-  def list(conn, stream_name, params \\ []) do
+  def list(conn, stream_name, domain \\ nil, params \\ []) do
     payload =
       Jason.encode!(%{
         offset: Keyword.get(params, :offset, 0)
       })
 
-    with {:ok, raw} <- request(conn, "$JS.API.CONSUMER.NAMES.#{stream_name}", payload) do
+    with {:ok, raw} <- request(conn, "#{js_api(domain)}.CONSUMER.NAMES.#{stream_name}", payload) do
       response = %{
         consumers: Map.get(raw, "consumers"),
         limit: Map.get(raw, "limit"),
@@ -351,6 +354,7 @@ defmodule Jetstream.API.Consumer do
           stream_name :: binary(),
           consumer_name :: binary(),
           reply_to :: String.t(),
+          domain :: nil | binary(),
           opts :: keyword()
         ) :: :ok
   def request_next_message(
@@ -358,6 +362,7 @@ defmodule Jetstream.API.Consumer do
         stream_name,
         consumer_name,
         reply_to,
+        domain \\ nil,
         opts \\ []
       ) do
     default_payload = %{batch: 1}
@@ -379,11 +384,16 @@ defmodule Jetstream.API.Consumer do
 
     Gnat.pub(
       conn,
-      "$JS.API.CONSUMER.MSG.NEXT.#{stream_name}.#{consumer_name}",
+      "#{js_api(domain)}.CONSUMER.MSG.NEXT.#{stream_name}.#{consumer_name}",
       payload,
       reply_to: reply_to
     )
   end
+
+  # https://docs.nats.io/running-a-nats-service/configuration/leafnodes/jetstream_leafnodes
+  defp js_api(nil), do: "$JS.API"
+  defp js_api(""), do: "$JS.API"
+  defp js_api(domain), do: "$JS.#{domain}.API"
 
   defp create_payload(%__MODULE__{} = cons) do
     %{

--- a/lib/jetstream/api/consumer.ex
+++ b/lib/jetstream/api/consumer.ex
@@ -229,7 +229,8 @@ defmodule Jetstream.API.Consumer do
   """
   @spec create(conn :: Gnat.t(), consumer :: t()) :: {:ok, info()} | {:error, term()}
   def create(conn, %__MODULE__{durable_name: name} = consumer) when not is_nil(name) do
-    create_topic = "#{js_api(consumer.domain)}.CONSUMER.DURABLE.CREATE.#{consumer.stream_name}.#{name}"
+    create_topic =
+      "#{js_api(consumer.domain)}.CONSUMER.DURABLE.CREATE.#{consumer.stream_name}.#{name}"
 
     with :ok <- validate_durable(consumer),
          {:ok, raw_response} <- request(conn, create_topic, create_payload(consumer)) do
@@ -259,7 +260,12 @@ defmodule Jetstream.API.Consumer do
       iex> {:error, %{"code" => 404, "description" => "stream not found"}} = Jetstream.API.Consumer.delete(:gnat, "wrong_stream", "consumer")
 
   """
-  @spec delete(conn :: Gnat.t(), stream_name :: binary(), consumer_name :: binary(), domain :: nil | binary()) ::
+  @spec delete(
+          conn :: Gnat.t(),
+          stream_name :: binary(),
+          consumer_name :: binary(),
+          domain :: nil | binary()
+        ) ::
           :ok | {:error, any()}
   def delete(conn, stream_name, consumer_name, domain \\ nil) do
     topic = "#{js_api(domain)}.CONSUMER.DELETE.#{stream_name}.#{consumer_name}"
@@ -281,7 +287,12 @@ defmodule Jetstream.API.Consumer do
       iex>  {:error, %{"code" => 404, "description" => "stream not found"}} = Jetstream.API.Consumer.info(:gnat, "wrong_stream", "consumer")
 
   """
-  @spec info(conn :: Gnat.t(), stream_name :: binary(), consumer_name :: binary(), domain :: nil | binary()) ::
+  @spec info(
+          conn :: Gnat.t(),
+          stream_name :: binary(),
+          consumer_name :: binary(),
+          domain :: nil | binary()
+        ) ::
           {:ok, info()} | {:error, any()}
   def info(conn, stream_name, consumer_name, domain \\ nil) do
     topic = "#{js_api(domain)}.CONSUMER.INFO.#{stream_name}.#{consumer_name}"
@@ -302,10 +313,15 @@ defmodule Jetstream.API.Consumer do
       iex> {:error, %{"code" => 404, "description" => "stream not found"}} = Jetstream.API.Consumer.list(:gnat, "wrong_stream")
 
   """
-  @spec list(conn :: Gnat.t(), stream_name :: binary(), params :: [offset: non_neg_integer(), domain: nil | binary()]) ::
+  @spec list(
+          conn :: Gnat.t(),
+          stream_name :: binary(),
+          params :: [offset: non_neg_integer(), domain: nil | binary()]
+        ) ::
           {:ok, consumers()} | {:error, term()}
   def list(conn, stream_name, params \\ []) do
     domain = Keyword.get(params, :domain)
+
     payload =
       Jason.encode!(%{
         offset: Keyword.get(params, :offset, 0)

--- a/lib/jetstream/api/consumer.ex
+++ b/lib/jetstream/api/consumer.ex
@@ -302,9 +302,10 @@ defmodule Jetstream.API.Consumer do
       iex> {:error, %{"code" => 404, "description" => "stream not found"}} = Jetstream.API.Consumer.list(:gnat, "wrong_stream")
 
   """
-  @spec list(conn :: Gnat.t(), stream_name :: binary(), domain :: nil | binary(), params :: [offset: non_neg_integer()]) ::
+  @spec list(conn :: Gnat.t(), stream_name :: binary(), params :: [offset: non_neg_integer(), domain: nil | binary()]) ::
           {:ok, consumers()} | {:error, term()}
-  def list(conn, stream_name, domain \\ nil, params \\ []) do
+  def list(conn, stream_name, params \\ []) do
+    domain = Keyword.get(params, :domain)
     payload =
       Jason.encode!(%{
         offset: Keyword.get(params, :offset, 0)

--- a/lib/jetstream/api/kv.ex
+++ b/lib/jetstream/api/kv.ex
@@ -195,7 +195,8 @@ defmodule Jetstream.API.KV do
 
       iex>{:ok, %{"key1" => "value1"}} = Jetstream.API.KV.contents(:gnat, "my_bucket")
   """
-  @spec contents(conn :: Gnat.t(), bucket_name :: binary(), domain :: nil | binary()) :: {:ok, map()} | {:error, binary()}
+  @spec contents(conn :: Gnat.t(), bucket_name :: binary(), domain :: nil | binary()) ::
+          {:ok, map()} | {:error, binary()}
   def contents(conn, bucket_name, domain \\ nil) do
     stream = stream_name(bucket_name)
     inbox = Util.reply_inbox()

--- a/lib/jetstream/api/kv.ex
+++ b/lib/jetstream/api/kv.ex
@@ -195,8 +195,8 @@ defmodule Jetstream.API.KV do
 
       iex>{:ok, %{"key1" => "value1"}} = Jetstream.API.KV.contents(:gnat, "my_bucket")
   """
-  @spec contents(conn :: Gnat.t(), bucket_name :: binary()) :: {:ok, map()} | {:error, binary()}
-  def contents(conn, bucket_name) do
+  @spec contents(conn :: Gnat.t(), bucket_name :: binary(), domain :: nil | binary()) :: {:ok, map()} | {:error, binary()}
+  def contents(conn, bucket_name, domain \\ nil) do
     stream = stream_name(bucket_name)
     inbox = Util.reply_inbox()
     consumer_name = "all_key_values_consumer_#{Util.nuid()}"
@@ -207,6 +207,7 @@ defmodule Jetstream.API.KV do
              durable_name: consumer_name,
              deliver_subject: inbox,
              stream_name: stream,
+             domain: domain,
              ack_policy: :none,
              max_ack_pending: -1,
              max_deliver: 1
@@ -214,7 +215,7 @@ defmodule Jetstream.API.KV do
       keys = receive_keys(bucket_name)
 
       :ok = Gnat.unsub(conn, sub)
-      :ok = Consumer.delete(conn, stream, consumer_name)
+      :ok = Consumer.delete(conn, stream, consumer_name, domain)
 
       {:ok, keys}
     end

--- a/lib/jetstream/api/kv/watcher.ex
+++ b/lib/jetstream/api/kv/watcher.ex
@@ -30,16 +30,6 @@ defmodule Jetstream.API.KV.Watcher do
     GenServer.stop(pid)
   end
 
-  @spec init(keyword) ::
-          {:ok,
-           %{
-             bucket_name: any,
-             conn: any,
-             consumer_name: <<_::64, _::_*8>>,
-             domain: any,
-             handler: any,
-             sub: binary | non_neg_integer
-           }}
   def init(opts) do
     {:ok, {sub, consumer_name}} = subscribe(opts[:conn], opts[:bucket_name])
 

--- a/lib/jetstream/api/object.ex
+++ b/lib/jetstream/api/object.ex
@@ -54,7 +54,7 @@ defmodule Jetstream.API.Object do
          {:ok, body} <- Jason.encode(meta),
          {:ok, _msg} <- Gnat.request(conn, topic, body, headers: [{"Nats-Rollup", "sub"}]) do
       filter = chunk_stream_topic(meta)
-      Stream.purge(conn, stream_name(bucket_name), %{filter: filter})
+      Stream.purge(conn, stream_name(bucket_name), nil, %{filter: filter})
     end
   end
 
@@ -209,7 +209,7 @@ defmodule Jetstream.API.Object do
   defp purge_prior_chunks(conn, bucket, name) do
     case info(conn, bucket, name) do
       {:ok, meta} ->
-        Stream.purge(conn, stream_name(bucket), %{filter: chunk_stream_topic(meta)})
+        Stream.purge(conn, stream_name(bucket), nil, %{filter: chunk_stream_topic(meta)})
 
       {:error, %{"code" => 404}} ->
         :ok

--- a/lib/jetstream/api/stream.ex
+++ b/lib/jetstream/api/stream.ex
@@ -266,7 +266,11 @@ defmodule Jetstream.API.Stream do
   def create(conn, %__MODULE__{} = stream) do
     with :ok <- validate(stream),
          {:ok, stream} <-
-           request(conn, "#{js_api(stream.domain)}.STREAM.CREATE.#{stream.name}", Jason.encode!(stream)) do
+           request(
+             conn,
+             "#{js_api(stream.domain)}.STREAM.CREATE.#{stream.name}",
+             Jason.encode!(stream)
+           ) do
       {:ok, to_info(stream)}
     end
   end
@@ -284,7 +288,11 @@ defmodule Jetstream.API.Stream do
   def update(conn, %__MODULE__{} = stream) do
     with :ok <- validate(stream),
          {:ok, stream} <-
-           request(conn, "#{js_api(stream.domain)}.STREAM.UPDATE.#{stream.name}", Jason.encode!(stream)) do
+           request(
+             conn,
+             "#{js_api(stream.domain)}.STREAM.UPDATE.#{stream.name}",
+             Jason.encode!(stream)
+           ) do
       {:ok, to_info(stream)}
     end
   end
@@ -301,7 +309,8 @@ defmodule Jetstream.API.Stream do
       iex> {:error, %{"code" => 404, "description" => "stream not found"}} = Jetstream.API.Stream.delete(:gnat, "wrong_stream")
 
   """
-  @spec delete(conn :: Gnat.t(), stream_name :: binary(), domain :: nil | binary()) :: :ok | {:error, any()}
+  @spec delete(conn :: Gnat.t(), stream_name :: binary(), domain :: nil | binary()) ::
+          :ok | {:error, any()}
   def delete(conn, stream_name, domain \\ nil) when is_binary(stream_name) do
     with {:ok, _response} <- request(conn, "#{js_api(domain)}.STREAM.DELETE.#{stream_name}", "") do
       :ok
@@ -320,7 +329,8 @@ defmodule Jetstream.API.Stream do
       iex> {:error, %{"code" => 404, "description" => "stream not found"}} = Jetstream.API.Stream.purge(:gnat, "wrong_stream")
 
   """
-  @spec purge(conn :: Gnat.t(), stream_name :: binary(), domain :: nil | binary()) :: :ok | {:error, any()}
+  @spec purge(conn :: Gnat.t(), stream_name :: binary(), domain :: nil | binary()) ::
+          :ok | {:error, any()}
   def purge(conn, stream_name, domain \\ nil) when is_binary(stream_name) do
     with {:ok, _response} <- request(conn, "#{js_api(domain)}.STREAM.PURGE.#{stream_name}", "") do
       :ok
@@ -338,7 +348,8 @@ defmodule Jetstream.API.Stream do
 
   """
   @type method :: %{filter: String.t()}
-  @spec purge(conn :: Gnat.t(), stream_name :: binary(), domain :: nil | binary(), method) :: :ok | {:error, any()}
+  @spec purge(conn :: Gnat.t(), stream_name :: binary(), domain :: nil | binary(), method) ::
+          :ok | {:error, any()}
   def purge(conn, stream_name, domain, method) when is_binary(stream_name) do
     with :ok <- validate_purge_method(method),
          body <- Jason.encode!(method),
@@ -379,10 +390,14 @@ defmodule Jetstream.API.Stream do
       iex> {:ok, %{total: _, offset: 0, limit: 1024, streams: _}} = Jetstream.API.Stream.list(:gnat)
 
   """
-  @spec list(conn :: Gnat.t(), params :: [offset: non_neg_integer(), subject: binary(), domain: nil | binary()]) ::
+  @spec list(
+          conn :: Gnat.t(),
+          params :: [offset: non_neg_integer(), subject: binary(), domain: nil | binary()]
+        ) ::
           {:ok, streams()} | {:error, term()}
   def list(conn, params \\ []) do
     domain = Keyword.get(params, :domain)
+
     payload =
       Jason.encode!(%{
         offset: Keyword.get(params, :offset, 0),
@@ -404,7 +419,12 @@ defmodule Jetstream.API.Stream do
   @doc """
   Get a message from the stream either by "stream sequence number" or the "last message for a given subject"
   """
-  @spec get_message(conn :: Gnat.t(), stream_name :: binary(),  method :: message_access_method(), domain :: nil | binary()) ::
+  @spec get_message(
+          conn :: Gnat.t(),
+          stream_name :: binary(),
+          method :: message_access_method(),
+          domain :: nil | binary()
+        ) ::
           {:ok, message_response()} | {:error, response_error()}
   def get_message(conn, stream_name, method, domain \\ nil) when is_map(method) do
     with :ok <- validate_message_access_method(method),

--- a/lib/jetstream/api/stream.ex
+++ b/lib/jetstream/api/stream.ex
@@ -379,9 +379,10 @@ defmodule Jetstream.API.Stream do
       iex> {:ok, %{total: _, offset: 0, limit: 1024, streams: _}} = Jetstream.API.Stream.list(:gnat)
 
   """
-  @spec list(conn :: Gnat.t(), domain :: nil | binary(), params :: [{:offset, non_neg_integer()}, {:subject, binary()}]) ::
+  @spec list(conn :: Gnat.t(), params :: [offset: non_neg_integer(), subject: binary(), domain: nil | binary()]) ::
           {:ok, streams()} | {:error, term()}
-  def list(conn, domain \\ nil, params \\ []) do
+  def list(conn, params \\ []) do
+    domain = Keyword.get(params, :domain)
     payload =
       Jason.encode!(%{
         offset: Keyword.get(params, :offset, 0),

--- a/lib/jetstream/pull_consumer.ex
+++ b/lib/jetstream/pull_consumer.ex
@@ -71,6 +71,7 @@ defmodule Jetstream.PullConsumer do
     connection. When this value is exceeded, the pull consumer stops with the `:timeout` reason,
     defaults to `10`
   * `:inbox_prefix` - allows the default `_INBOX.` prefix to be customized. Should end with a dot.
+  * `:domain` - use a JetStream domain, this is mostly used on leaf nodes.
 
   ## Dynamic Connection Options
 
@@ -203,6 +204,7 @@ defmodule Jetstream.PullConsumer do
           | {:consumer_name, String.t()}
           | {:connection_retry_timeout, non_neg_integer()}
           | {:connection_retries, non_neg_integer()}
+          | {:domain, String.t()}
 
   @typedoc """
   Connection options used to connect the consumer to NATS server.

--- a/lib/jetstream/pull_consumer/connection_options.ex
+++ b/lib/jetstream/pull_consumer/connection_options.ex
@@ -10,7 +10,8 @@ defmodule Jetstream.PullConsumer.ConnectionOptions do
     :consumer_name,
     :connection_retry_timeout,
     :connection_retries,
-    :inbox_prefix
+    :inbox_prefix,
+    :domain
   ]
 
   defstruct @enforce_keys
@@ -26,7 +27,8 @@ defmodule Jetstream.PullConsumer.ConnectionOptions do
           :consumer_name,
           connection_retry_timeout: @default_retry_timeout,
           connection_retries: @default_retries,
-          inbox_prefix: nil
+          inbox_prefix: nil,
+          domain: nil
         ])
       )
     end
@@ -38,7 +40,8 @@ defmodule Jetstream.PullConsumer.ConnectionOptions do
           [
             connection_retry_timeout: @default_retry_timeout,
             connection_retries: @default_retries,
-            inbox_prefix: nil
+            inbox_prefix: nil,
+            domain: nil
           ],
           connection_options
         )

--- a/lib/jetstream/pull_consumer/server.ex
+++ b/lib/jetstream/pull_consumer/server.ex
@@ -52,7 +52,7 @@ defmodule Jetstream.PullConsumer.Server do
             connection_name: connection_name,
             connection_retry_timeout: connection_retry_timeout,
             connection_retries: connection_retries,
-            domain: domain,
+            domain: domain
           },
           listening_topic: listening_topic,
           module: module

--- a/lib/jetstream/pull_consumer/server.ex
+++ b/lib/jetstream/pull_consumer/server.ex
@@ -51,7 +51,8 @@ defmodule Jetstream.PullConsumer.Server do
             consumer_name: consumer_name,
             connection_name: connection_name,
             connection_retry_timeout: connection_retry_timeout,
-            connection_retries: connection_retries
+            connection_retries: connection_retries,
+            domain: domain,
           },
           listening_topic: listening_topic,
           module: module
@@ -66,10 +67,10 @@ defmodule Jetstream.PullConsumer.Server do
 
     with {:ok, conn} <- connection_pid(connection_name),
          Process.link(conn),
-         :ok <- check_consumer_exists(connection_name, stream_name, consumer_name),
+         :ok <- check_consumer_exists(connection_name, stream_name, consumer_name, domain),
          {:ok, sid} <- Gnat.sub(conn, self(), listening_topic),
          gen_state = %{gen_state | subscription_id: sid},
-         :ok <- next_message(conn, stream_name, consumer_name, listening_topic),
+         :ok <- next_message(conn, stream_name, consumer_name, domain, listening_topic),
          gen_state = %{gen_state | current_retry: 0} do
       {:ok, gen_state}
     else
@@ -140,8 +141,8 @@ defmodule Jetstream.PullConsumer.Server do
     end
   end
 
-  defp check_consumer_exists(gnat, stream_name, consumer_name) do
-    case Jetstream.API.Consumer.info(gnat, stream_name, consumer_name) do
+  defp check_consumer_exists(gnat, stream_name, consumer_name, domain) do
+    case Jetstream.API.Consumer.info(gnat, stream_name, consumer_name, domain) do
       {:ok, _consumer} ->
         :ok
 
@@ -171,7 +172,8 @@ defmodule Jetstream.PullConsumer.Server do
           connection_options: %ConnectionOptions{
             stream_name: stream_name,
             consumer_name: consumer_name,
-            connection_name: connection_name
+            connection_name: connection_name,
+            domain: domain
           },
           listening_topic: listening_topic,
           subscription_id: subscription_id,
@@ -204,6 +206,7 @@ defmodule Jetstream.PullConsumer.Server do
           message.gnat,
           stream_name,
           consumer_name,
+          domain,
           listening_topic
         )
 
@@ -217,6 +220,7 @@ defmodule Jetstream.PullConsumer.Server do
           message.gnat,
           stream_name,
           consumer_name,
+          domain,
           listening_topic
         )
 
@@ -228,6 +232,7 @@ defmodule Jetstream.PullConsumer.Server do
           message.gnat,
           stream_name,
           consumer_name,
+          domain,
           listening_topic
         )
 
@@ -314,12 +319,13 @@ defmodule Jetstream.PullConsumer.Server do
     {:disconnect, {:close, from}, gen_state}
   end
 
-  defp next_message(conn, stream_name, consumer_name, listening_topic) do
+  defp next_message(conn, stream_name, consumer_name, domain, listening_topic) do
     Jetstream.API.Consumer.request_next_message(
       conn,
       stream_name,
       consumer_name,
-      listening_topic
+      listening_topic,
+      domain
     )
   end
 end

--- a/lib/off_broadway/producer.ex
+++ b/lib/off_broadway/producer.ex
@@ -17,6 +17,7 @@ with {:module, _} <- Code.ensure_compiled(Broadway) do
 
     * `consumer_name` - The name of consumer.
 
+
     Optional options:
 
     * `connection_retry_timeout` - time in milliseconds, after which the failing
@@ -26,6 +27,8 @@ with {:module, _} <- Code.ensure_compiled(Broadway) do
       make before shutting down. Defaults to `10`.
 
     * `inbox_prefix` - custom prefix for listening topic. Defaults to `_INBOX.`.
+
+    * `domain` - Jetstream domain.
 
     ### Message pulling options
 
@@ -161,7 +164,8 @@ with {:module, _} <- Code.ensure_compiled(Broadway) do
           :consumer_name,
           :connection_retry_timeout,
           :connection_retries,
-          :inbox_prefix
+          :inbox_prefix,
+          :domain,
         ])
         |> ConnectionOptions.validate!()
 
@@ -204,7 +208,7 @@ with {:module, _} <- Code.ensure_compiled(Broadway) do
               %ConnectionOptions{
                 connection_name: connection_name,
                 connection_retries: retries,
-                connection_retry_timeout: retry_timeout
+                connection_retry_timeout: retry_timeout,
               } = conn_options,
             listening_topic: listening_topic,
             connection_retries_left: retries_left
@@ -348,6 +352,7 @@ with {:module, _} <- Code.ensure_compiled(Broadway) do
         state.connection_options.stream_name,
         state.connection_options.consumer_name,
         state.listening_topic,
+        state.connection_options.domain,
         batch: total_demand,
         no_wait: true
       )

--- a/lib/off_broadway/producer.ex
+++ b/lib/off_broadway/producer.ex
@@ -165,7 +165,7 @@ with {:module, _} <- Code.ensure_compiled(Broadway) do
           :connection_retry_timeout,
           :connection_retries,
           :inbox_prefix,
-          :domain,
+          :domain
         ])
         |> ConnectionOptions.validate!()
 
@@ -208,7 +208,7 @@ with {:module, _} <- Code.ensure_compiled(Broadway) do
               %ConnectionOptions{
                 connection_name: connection_name,
                 connection_retries: retries,
-                connection_retry_timeout: retry_timeout,
+                connection_retry_timeout: retry_timeout
               } = conn_options,
             listening_topic: listening_topic,
             connection_retries_left: retries_left

--- a/test/jetstream/api/consumer_test.exs
+++ b/test/jetstream/api/consumer_test.exs
@@ -228,7 +228,9 @@ defmodule Jetstream.API.ConsumerTest do
       consumer_name: consumer_name,
       reply_subject: reply_subject
     } do
-      Consumer.request_next_message(:gnat, stream_name, consumer_name, reply_subject, nil, batch: 10)
+      Consumer.request_next_message(:gnat, stream_name, consumer_name, reply_subject, nil,
+        batch: 10
+      )
 
       Gnat.pub(:gnat, subject, "message 1")
 

--- a/test/jetstream/api/consumer_test.exs
+++ b/test/jetstream/api/consumer_test.exs
@@ -228,7 +228,7 @@ defmodule Jetstream.API.ConsumerTest do
       consumer_name: consumer_name,
       reply_subject: reply_subject
     } do
-      Consumer.request_next_message(:gnat, stream_name, consumer_name, reply_subject, batch: 10)
+      Consumer.request_next_message(:gnat, stream_name, consumer_name, reply_subject, nil, batch: 10)
 
       Gnat.pub(:gnat, subject, "message 1")
 
@@ -253,7 +253,7 @@ defmodule Jetstream.API.ConsumerTest do
       consumer_name: consumer_name,
       reply_subject: reply_subject
     } do
-      Consumer.request_next_message(:gnat, stream_name, consumer_name, reply_subject,
+      Consumer.request_next_message(:gnat, stream_name, consumer_name, reply_subject, nil,
         no_wait: true
       )
 
@@ -275,7 +275,7 @@ defmodule Jetstream.API.ConsumerTest do
         assert {:ok, _} = Gnat.request(:gnat, subject, "message #{i}")
       end
 
-      Consumer.request_next_message(:gnat, stream_name, consumer_name, reply_subject,
+      Consumer.request_next_message(:gnat, stream_name, consumer_name, reply_subject, nil,
         batch: 10,
         no_wait: true
       )

--- a/test/jetstream/api/stream_test.exs
+++ b/test/jetstream/api/stream_test.exs
@@ -54,7 +54,7 @@ defmodule Jetstream.API.StreamTest do
     stream = %Stream{name: "LIST_SUBJECT_TEST_TWO", subjects: ["LIST_SUBJECT_TEST.subject2"]}
     {:ok, _response} = Stream.create(:gnat, stream)
 
-    {:ok, %{streams: [stream]}} = Stream.list(:gnat, nil, subject: "LIST_SUBJECT_TEST.subject2")
+    {:ok, %{streams: [stream]}} = Stream.list(:gnat, subject: "LIST_SUBJECT_TEST.subject2")
     assert stream == "LIST_SUBJECT_TEST_TWO"
     assert :ok = Stream.delete(:gnat, "LIST_SUBJECT_TEST_ONE")
     assert :ok = Stream.delete(:gnat, "LIST_SUBJECT_TEST_TWO")
@@ -69,7 +69,7 @@ defmodule Jetstream.API.StreamTest do
     {:ok, %{streams: streams}} = Stream.list(:gnat)
     num_no_offset = Enum.count(streams)
 
-    {:ok, %{streams: streams}} = Stream.list(:gnat, nil, offset: 1)
+    {:ok, %{streams: streams}} = Stream.list(:gnat, offset: 1)
     num_with_offset = Enum.count(streams)
 
     # Checking offset functionality without a strict pattern match to keep this

--- a/test/jetstream/api/stream_test.exs
+++ b/test/jetstream/api/stream_test.exs
@@ -54,7 +54,7 @@ defmodule Jetstream.API.StreamTest do
     stream = %Stream{name: "LIST_SUBJECT_TEST_TWO", subjects: ["LIST_SUBJECT_TEST.subject2"]}
     {:ok, _response} = Stream.create(:gnat, stream)
 
-    {:ok, %{streams: [stream]}} = Stream.list(:gnat, subject: "LIST_SUBJECT_TEST.subject2")
+    {:ok, %{streams: [stream]}} = Stream.list(:gnat, nil, subject: "LIST_SUBJECT_TEST.subject2")
     assert stream == "LIST_SUBJECT_TEST_TWO"
     assert :ok = Stream.delete(:gnat, "LIST_SUBJECT_TEST_ONE")
     assert :ok = Stream.delete(:gnat, "LIST_SUBJECT_TEST_TWO")
@@ -69,7 +69,7 @@ defmodule Jetstream.API.StreamTest do
     {:ok, %{streams: streams}} = Stream.list(:gnat)
     num_no_offset = Enum.count(streams)
 
-    {:ok, %{streams: streams}} = Stream.list(:gnat, offset: 1)
+    {:ok, %{streams: streams}} = Stream.list(:gnat, nil, offset: 1)
     num_with_offset = Enum.count(streams)
 
     # Checking offset functionality without a strict pattern match to keep this


### PR DESCRIPTION
First of all thanks for this nice library! It helped us connecting our Elixir service to NATS JetStream :100: 

We are in the process of migrating to a new NATS setup which uses Leaf Nodes (https://docs.nats.io/running-a-nats-service/configuration/leafnodes). For this we needed to use JetStream domains. This PR adds support for configuring an optional domain parameter to streams and consumers.

Tested this change in a service.